### PR TITLE
Add Home Assistant -> SOSA/RDT exporter (tools/hass-to-rdt)

### DIFF
--- a/tools/hass-to-rdt/ConfigSource.py
+++ b/tools/hass-to-rdt/ConfigSource.py
@@ -1,0 +1,190 @@
+import argparse
+import functools
+import json
+import logging
+import os
+import socket
+import ssl
+import sys
+import urllib.parse
+
+import requests
+from forcediphttpsadapter.adapters import ForcedIPHTTPSAdapter
+from functools import cache
+import requests_cache
+import websocket
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class HAException(Exception):
+    pass
+
+
+class ConfigSource:
+    # session = requests_cache.CachedSession('my_cache')
+    session = requests.Session()
+    mount_ip = None  # XXX Doesn't really belong in here now that we have Flask.
+
+    def __init__(self, url, token):
+        self.hass_url = url
+        self.token = token
+        self.session.headers = {'Content-type': 'application/json',
+                                'Authorization': 'Bearer ' + token,
+                                'User-Agent': 'HOWL-exporter/0.1 vs+howl@foldr.org'
+                                }
+
+    def getYAML(self, query):
+        http_data = {'template': '{{ ' + query + ' }}'}
+        j_response = self.session.post(self.hass_url + "template", json=http_data)
+        if j_response.status_code == 401:
+            # Let's quickly check if the token is valid via GET:
+            self.getStates()
+            raise HAException("Your token does not seem to have admin privileges that the tool needs to execute some " \
+                          "queries via templates.\n Please obtain an admin-token and try again.")
+        assert j_response.status_code == 200, f"YAML request failed: " + str(j_response.text)
+        return yaml.safe_load(j_response.text)
+
+    def getYAMLText(self, query) -> str:
+        http_data = {'template': '{{ ' + query + ' }}'}
+        j_response = self.session.post(self.hass_url + "template", json=http_data)
+        assert j_response.status_code == 200, f"YAML request failed: " + str(j_response.text)
+        return j_response.text
+
+    @cache
+    def getDevices(self):
+        q = {'type': "config/device_registry/list", 'id': self.ws_counter}
+        self.ws_counter += 1
+        self.ws.send(json.dumps(q))
+        q_result = json.loads(self.ws.recv())
+        assert q_result['success'], q_result
+        r_list = q_result['result']
+        q_list = []
+        for r in r_list:
+            print(r)
+            q_list.append(r['id'])
+
+        # TODO: remove after enough testing
+        t = self.getYAML('states | map(attribute="entity_id")|map("device_id") | unique | reject("eq",None) | list')
+        failed_a = []
+        failed_b = []
+        for x in t:
+            if not (x in q_list):
+                failed_a.append(x)
+        for x in q_list:
+            if not(x in t):
+                failed_b.append(x)
+
+        # Sanity check for now:
+        assert len(failed_a) == 0, f"Not in ws: {failed_a}\nNot in REST: {failed_b}"
+        return q_list
+
+    def _ws_connect(self, certificate=None):
+        ws = websocket.WebSocket()
+        ws_url = "ws" + self.hass_url[4:] + "websocket"
+        header = ['User-Agent: HOWL-exporter/0.1 vs+howl@foldr.org']
+        if self.mount_ip is not None:
+            urlp = urllib.parse.urlparse(ws_url)
+            s = socket.create_connection((self.mount_ip, urlp.port))
+            if urlp.scheme == "wss":
+                if certificate is not None:
+                    if self.session.verify is None:
+                        ctx = ssl.create_default_context()
+                        ctx.verify_mode = ssl.CERT_NONE
+                    else:
+                        ctx = ssl.create_default_context(cafile=self.session.cert)
+                else:
+                    ctx = ssl.create_default_context()
+                s = ctx.wrap_socket(s, server_hostname=urlp.hostname)
+            ws.connect(ws_url, socket=s, header=header)
+        else:
+            if not (certificate is None):
+                if self.session.verify is None:
+                    sslopt = {"cert_reqs": ssl.CERT_NONE}
+                else:
+                    sslopt = {"ca_cert": self.session.cert}
+            else:
+                sslopt = {}
+            # Create a new connection because `connect` won't actually `sslopt` otherwise.
+            ws = websocket.WebSocket(sslopt=sslopt)
+            logger.info(f'Connecting to {ws_url}...')
+            ws.connect(ws_url, header=header)
+        welcome_msg = ws.recv()  # Consume hello-msg
+        assert welcome_msg.startswith('{"type":"auth_required"'), welcome_msg
+        q = {'type': "auth", 'access_token': self.token}
+        ws.send(json.dumps(q))
+        auth_result = json.loads(ws.recv())
+        assert auth_result['type'] == "auth_ok", auth_result
+        return ws
+
+    def getDeviceEntities(self, device):
+        return self.getYAML('device_entities("' + device + '")')
+
+    @cache
+    def getDeviceAttr(self, device, attr) -> str:
+        return self.getYAMLText('device_attr("' + device + '","' + attr + '")')
+
+    @cache
+    def getDeviceId(self, entity):
+        return self.getYAML(f'device_id("{entity}")')
+
+    @cache
+    def getAttributes(self, e):
+        # TODO: could bounce through cached getStates() now.
+        result = self.session.get(f"{self.hass_url}states/{e}")
+        j = json.loads(result.text)
+        return j['attributes'] if 'attributes' in j else {}
+
+    @cache
+    def getStates(self):
+        result = self.session.get(f"{self.hass_url}states")
+        return result.json()
+
+    @cache
+    def getServices(self):
+        result = self.session.get(f"{self.hass_url}services")
+        assert result.status_code == 200, (result.status_code, result.text)
+        out = {}
+        for k in result.json():
+            out[k['domain']] = k['services']
+        return out
+
+    @cache
+    def getAutomationConfig(self, automation_id):
+        result = self.session.get(f"{self.hass_url}config/automation/config/{automation_id}")
+        assert result.status_code == 200, (result.status_code, result.text)
+        return result.json()
+
+
+class CLISource(ConfigSource):
+
+    def __init__(self, parser: argparse.ArgumentParser):
+        parser.add_argument('url',
+                            help='Full path to API, e.g. https://homeassistant.local:8123/api/.')
+        parser.add_argument('token', metavar='TOKENVAR',
+                            help='Name of environment variable where you keep your long-lived access token. NOT THE LITERAL TOKEN!')
+        parser.add_argument('-m', '--mount', metavar='192.0.2.1',
+                            help='Use ForcedIPHTTPSAdapter to override IP for URL; useful on internal IPs.')
+        parser.add_argument('-c', '--certificate', metavar='ca.crt',
+                            help='Path to a CA certificate to validate your https-connection if needed. The string'
+                                 ' "None" will disable validation.')
+        args = parser.parse_args()  # TODO: could be more modular in the future
+        self.args = args  # We may need the results outside. XXX Not any more?
+        token = os.getenv(args.token)
+        if token is None:
+            print(f"Aborting: the environment variable for the token that you specified on the command line does not"
+                  f" seem to be set!", file=sys.stderr)
+            exit(1)
+        super().__init__(args.url, token)
+        # Set on-demand.
+        if args.mount is not None:
+            self.session.mount(args.url, ForcedIPHTTPSAdapter(dest_ip=args.mount))
+            self.mount_ip = args.mount
+        else:
+            self.mount_ip = None
+        if args.certificate is not None:
+            if args.certificate == "None":
+                self.session.verify = None
+            else:
+                self.session.verify = args.certificate

--- a/tools/hass-to-rdt/README.md
+++ b/tools/hass-to-rdt/README.md
@@ -1,0 +1,65 @@
+# Home Assistant → SOSA/RDT exporter
+
+CLI tool that connects to a [Home Assistant](https://www.home-assistant.io)
+instance and exports its structure (entities, sensors, actuators, possible
+actuator states) as a Turtle file using the **SOSA/SSN** vocabulary plus the
+`rdt:` namespace, ready to feed the inference engine.
+
+For each entity it emits `a sosa:Sensor` / `a sosa:Actuator`, attaches the raw
+Home Assistant `entity_id` via `rdt:hasIdentifier`, and enumerates possible
+actuator states (`rdt:hasActuatorState`) discovered from `/api/services` and the
+entity attributes (`fan`, `climate`, `cover`, `input_select`, …).
+
+## Setup
+
+```bash
+cd tools/hass-to-rdt
+python -m venv .venv
+.venv\Scripts\activate          # Windows
+# source .venv/bin/activate     # Linux/macOS
+pip install -r requirements-cli.txt
+```
+
+The `homeassistant` package pulls in most transitive deps; first install can
+take a couple of minutes.
+
+## Usage
+
+You need a Home Assistant API URL and an **admin** long-lived access token
+([how to create one](https://developers.home-assistant.io/docs/auth_api/#long-lived-access-token)).
+Store the token in an environment variable — never pass the literal token on the
+command line.
+
+```powershell
+$env:TOKEN_HA = "<your-long-lived-token>"
+
+python hacvt_rdt.py http://localhost:8123/api/ TOKEN_HA `
+    --namespace http://example.org/ha/ `
+    --out homeassistant-ha-instance.ttl
+```
+
+The second positional argument is the **name** of the env var holding the token,
+not the token itself.
+
+### Options
+
+```
+usage: hacvt_rdt.py [-h] [-n NAMESPACE] [-o OUT] [-p [platform* ...]]
+                    [-m IP] [-c ca.crt] url TOKENVAR
+
+  url               HA API root, e.g. http://localhost:8123/api/.
+  TOKENVAR          Name of the env var holding the long-lived token.
+  -n, --namespace   RDF namespace for individuals.
+  -o, --out         Output Turtle filename.
+  -p, --privacy     Enable privacy filter.
+  -m, --mount       ForcedIPHTTPSAdapter override IP for internal HA URLs.
+  -c, --certificate Path to CA cert; "None" disables validation.
+```
+
+## Tests
+
+Offline, no live Home Assistant and no token required:
+
+```bash
+python -m pytest tools/hass-to-rdt/tests -q
+```

--- a/tools/hass-to-rdt/actuator_states.py
+++ b/tools/hass-to-rdt/actuator_states.py
@@ -1,0 +1,102 @@
+"""
+actuator_states.py — Domain-specific actuator state extractors
+==============================================================
+Pure-Python helpers with no dependency on the ``homeassistant`` package.
+Each extractor receives:
+  - ``attrs``       : dict of entity attributes returned by HA's /api/states
+  - ``service_info``: dict of service definitions for the domain (may be {})
+and returns a list of state strings to emit as ``rdt:hasActuatorState`` literals.
+
+Imported by hacvt_rdt.py and tested independently in tests/test_actuator_states.py.
+"""
+
+import sys
+
+
+def extract_fan_states(attrs: dict, service_info: dict) -> list[str]:
+    """
+    Priority: preset_modes > speed_list > percentage_step range.
+
+    If both preset_modes and speed_list are present the function returns both
+    (preset_modes first, unique speed_list values appended) and prints a
+    warning to stderr so the ontology engineer can decide which source to trust.
+    When neither list is available a discrete percentage scale is built from
+    percentage_step (e.g. step=25 → pct:0, pct:25, pct:50, pct:75, pct:100).
+    """
+    preset_modes = attrs.get("preset_modes") or []
+    speed_list   = attrs.get("speed_list") or []
+    pct_step     = attrs.get("percentage_step")
+
+    states: list[str] = []
+
+    if preset_modes:
+        states.extend(str(m) for m in preset_modes)
+
+    if speed_list:
+        if preset_modes:
+            print(
+                "WARNING: fan entity exposes both preset_modes and speed_list"
+                f" — emitting both (preset_modes={list(preset_modes)},"
+                f" speed_list={list(speed_list)})",
+                file=sys.stderr,
+            )
+        states.extend(str(s) for s in speed_list if str(s) not in states)
+
+    if not states and pct_step is not None:
+        try:
+            step = float(pct_step)
+            if 0 < step <= 100:
+                pct = 0.0
+                while pct <= 100.0:
+                    states.append(f"pct:{int(pct)}")
+                    pct += step
+        except (TypeError, ValueError):
+            pass
+
+    return states
+
+
+def extract_climate_states(attrs: dict, service_info: dict) -> list[str]:
+    """
+    Concatenates four HA climate attribute lists, prefixing sub-lists to
+    avoid value collisions:
+      - hvac_modes   → bare strings (e.g. "heat", "cool", "off")
+      - preset_modes → "preset:<value>"
+      - fan_modes    → "fan:<value>"
+      - swing_modes  → "swing:<value>"
+    """
+    states: list[str] = []
+
+    for mode in attrs.get("hvac_modes") or []:
+        states.append(str(mode))
+
+    for mode in attrs.get("preset_modes") or []:
+        states.append(f"preset:{mode}")
+
+    for mode in attrs.get("fan_modes") or []:
+        states.append(f"fan:{mode}")
+
+    for mode in attrs.get("swing_modes") or []:
+        states.append(f"swing:{mode}")
+
+    return states
+
+
+def extract_cover_states(attrs: dict, service_info: dict) -> list[str]:
+    """
+    If the entity reports a tilt position (``current_tilt_position`` key is
+    present in attrs, regardless of value), return three positions:
+    open, half-open, closed.  Otherwise return the two standard positions:
+    open, closed.
+
+    Note: the toggle states open/closed/stop are already emitted by
+    _TOGGLE_OVERRIDE in hacvt_rdt.py; deduplication happens there.
+    """
+    if "current_tilt_position" in attrs:
+        return ["open", "half-open", "closed"]
+    return ["open", "closed"]
+
+
+def extract_input_select_states(attrs: dict, service_info: dict) -> list[str]:
+    """Return the ``options`` list verbatim, coercing each item to str."""
+    return [str(o) for o in (attrs.get("options") or [])]

--- a/tools/hass-to-rdt/hacvt.py
+++ b/tools/hass-to-rdt/hacvt.py
@@ -1,0 +1,999 @@
+import argparse
+
+import homeassistant.const as hc
+import homeassistant.core as ha
+from homeassistant.helpers.trigger import _PLATFORM_ALIASES
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components import (
+    automation,
+    binary_sensor,
+    button,
+    climate,
+    device_automation,
+    fan,
+    light,
+    mqtt,
+    remote,
+    sensor,
+    sun,
+    switch,
+    zone,
+)
+import homeassistant.components.button.device_action
+import homeassistant.components.climate.device_action
+import homeassistant.components.fan.device_action
+import homeassistant.components.light.device_action
+import homeassistant.components.mqtt.device_trigger
+import homeassistant.components.switch.device_action
+import homeassistant.components.zone.trigger
+
+# Import some constants for later use: obviously this ain't gonna scale!
+from homeassistant.components.binary_sensor.device_trigger import CONF_MOTION, CONF_NO_MOTION
+# from homeassistant.components.deconz.device_trigger import CONF_SHORT_PRESS, CONF_LONG_PRESS
+
+from functools import cache
+import logging
+from rdflib import Literal, Graph, URIRef
+from rdflib.namespace import Namespace, RDF, RDFS, OWL, XSD
+from typing import Optional
+
+from ConfigSource import CLISource
+
+
+class PrivacyFilter:
+    p_counter = 0  # Used to enumerate privatized entity names
+    privacy_filter = None
+
+    def __init__(self, cs):
+        self.cs = cs
+
+    def privacyFilter_init(self, privacy=None):
+        # BEGIN Privacy settings:
+
+        # then some common ones. Set to privacy_filter to None to disable. The code-layout here should make it
+        # easy to comment out/in individual items.
+        if privacy is None:
+            self.privacy_filter = None
+        elif len(privacy) == 0:  # Just -p
+            self.privacy_filter = set(str(p) for p in hc.Platform)
+            # Identifier for devices in your system:
+            self.privacy_filter.add("device")
+            # Useful components that we usually want exported that are not part of home-assistant's core:
+            for p in {"automation", "climate", "input_datetime", "sun", "time"}:
+                self.privacy_filter.add(p)
+            # Common things that you may want to adjust to keep them private and that are not part of the based platforms:
+            self.privacy_filter.discard("device_tracker")  # Anonymize your mobile devices if you use the app.
+            # privacy_filter.add("person")              # Export our accounts in home-assistant.
+            self.privacy_filter.add("area")  # Export your self-defined area-names...
+            self.privacy_filter.add("zone")  # ... and zones.
+        else:  # -p platform1 platform2 ...
+            self.privacy_filter = set(privacy)
+        # Log what we're doing:
+        msg = "ALL" if self.privacy_filter is None else str(self.privacy_filter)
+        logging.info(f"Preserving entities: {msg}")
+
+    def mkEntityURI(self, MINE, entity_id) -> tuple[URIRef, str]:
+        # TODO: Not sure what we want to assume here for uniqueness...probably want to keep domain.name instead of
+        #  discarding it? Note that adding may happen somewhere else, as does setting a `friendly name` if it exists.
+        try:
+            e_platform, e_name = ha.split_entity_id(entity_id)
+            # we use a white-list in the privacy filter:
+            if self.privacy_filter is not None and e_platform not in self.privacy_filter:
+                e_name = "entity_" + str(self.p_counter)
+                self.p_counter = self.p_counter + 1
+            return MINE["entity/" + e_platform + "_" + mkname(e_name)], e_name
+        except:
+            logging.fatal(f"Can't process URI {entity_id}.")
+            raise
+
+    def mkLocationURI(self, MINE, name):
+        if self.privacy_filter is not None and "area" not in self.privacy_filter:
+            name = "entity_" + str(self.p_counter)
+            self.p_counter = self.p_counter + 1
+        return MINE["area/" + mkname(name)]
+
+    def mkDevice(self, MINE, device_id):
+        d2_name = self.cs.getDeviceAttr(device_id, 'name')
+        d2_name_by_user = "None"
+        if self.privacy_filter is not None and "device" not in self.privacy_filter:
+            d2_name = "device_" + str(self.p_counter)
+            p_counter = self.p_counter + 1
+        else:
+            # TODO: Defer this in favour of RDFS.label
+            d2_name_by_user = self.cs.getDeviceAttr(device_id, 'name_by_user')
+        return MINE[mkname(d2_name if d2_name_by_user == "None" else d2_name_by_user)]
+
+
+def mkname(name):
+    if isinstance(name, (int, float)):
+        name = str(name)
+    return name.replace(" ", "_").replace("/", "_")
+
+
+# TODOs
+# - escape "/" in names!
+
+class HACVT:
+
+    def __init__(self, cs):
+        self.cs = cs
+
+    def main(self, debug=logging.INFO, certificate=None, privacy=None, namespace="http://my.name.space/"):
+        logging.basicConfig(level=debug, format='%(levelname)s: %(message)s')
+        self.cs.ws = self.cs._ws_connect(certificate=certificate)
+        self.cs.ws_counter = 1
+
+        pf = PrivacyFilter(self.cs)
+        pf.privacyFilter_init(privacy=privacy)
+        g = Graph(bind_namespaces="core")
+        MINE, HASS, SAREF, S4BLDG, class_to_saref, master = self.setupSAREF(g, namespace, importsOnly=False)
+        # Save metamodel:
+        f_out = open("homeassistantcore.rdf", "w")
+        print(g.serialize(format='application/rdf+xml'), file=f_out)
+        # ... and get us a fresh graph:
+        g = Graph(bind_namespaces="core")
+        MINE, HASS, SAREF, S4BLDG, _, master = self.setupSAREF(g, namespace, importsOnly=True)
+        g.add((URIRef(str(MINE)), OWL.imports, URIRef(str(HASS))))
+
+        the_devices = self.cs.getDevices()
+        for d in the_devices:
+            d_g = pf.mkDevice(MINE, d)
+            # https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/device_registry.py
+            # For these we don't have constants.
+            # TODO: table-based conversion, manufacturer -> hasManufacturer,
+            #  maybe with lambdas for transformation?
+            manufacturer = self.cs.getDeviceAttr(d, hc.ATTR_MANUFACTURER)
+            name = self.cs.getDeviceAttr(d, hc.ATTR_NAME)
+            model = self.cs.getDeviceAttr(d, hc.ATTR_MODEL)
+            # O'sama denn hier? TODO.
+            entry_type = self.cs.getDeviceAttr(d, 'entry_type')
+            if not entry_type == "None":
+                logging.info(f"Found {d} {name} as: {entry_type}")
+                g.add((d_g, HASS["entry_type"], Literal(entry_type)))
+
+            # We create a super-class from the model. Eg. we have identical light bulbs, or motion sensors, or...
+            d_super = MINE['device/' + mkname(manufacturer)+"_"+mkname(model)]
+            g.add((d_super, RDFS.subClassOf, SAREF['Device']))
+
+            # The following is of course already a design-decision. We just create a container w/o particular type.
+            # That's what the SAREF-people did in the windmill-example.
+            g.add((d_g, RDF.type, d_super))
+            # TODO: it feels a bit weird to slap values onto a (singleton-) type, so we do it on each instance.
+            #  Check with Fernando.
+            g.add((d_g, SAREF['hasManufacturer'], Literal(manufacturer)))
+            g.add((d_g, SAREF['hasModel'], Literal(model)))
+
+            # Handle 'Area' of devices. May be None.
+            # TODO: Entities can override this individually.
+            d_area = self.cs.getYAMLText(f'area_id("{d}")')
+            area_name = self.cs.getYAMLText(f'area_name("{d}")')
+            if not d_area == "None":  # Careful, string!
+                area = pf.mkLocationURI(MINE, d_area)
+                g.add((area, RDF.type, S4BLDG['BuildingSpace']))
+                g.add((area, S4BLDG['contains'], d_g))
+                if pf.privacy_filter is None or "area" in pf.privacy_filter:
+                  g.add((area, RDFS.label, Literal(area_name)))
+            # END Area
+
+            # Handle `via_device` if present.
+            via = self.cs.getDeviceAttr(d, hc.ATTR_VIA_DEVICE)
+            if via != "None":
+                # Matches construction of d_g above:
+                other = pf.mkDevice(MINE, via)
+                logging.info(f"Found via({d},{via})")
+                g.add((d_g, HASS['via_device'], other))
+            # END via_device
+
+            es = self.cs.getDeviceEntities(d)
+
+            if len(es) == 0:
+                logging.info(f"Device {name} does not have any entities?!")
+            # elif len(es) == 1:
+            #     # Only one device, let's special-case
+            #     eprint(f"WARN: Device {name} does only have a single entity {es[0]}.")
+            #     continue  # TODO
+            else:
+                # Create sub-devices
+
+                # Let's ignore those as spam for now.
+                # Note that we don't seem to see the underlying radio-properties RSSI, LQI
+                # that HA is hiding explicitly in the UI.
+                def checkName(n):
+                    assert n.count('.') == 1
+                    (_domain, e_name) = ha.split_entity_id(n)
+                    return not (e_name.endswith("_identify") or e_name.endswith("_identifybutton"))
+
+                for e in filter(checkName, es):
+                    e_d = self.handle_entity(pf, HASS, MINE, SAREF, class_to_saref, d, e, g, master)
+                    if e_d is not None:
+                        # Derived entities and helpers are their own devices:
+                        g.add((d_g, SAREF['consistsOf'], e_d))
+
+        for e in self.getEntitiesWODevice():
+            # These have an empty inverse of `consistsOf`
+            platform, name = ha.split_entity_id(e['entity_id'])
+            # Not a constant?
+            if platform == automation.const.DOMAIN:
+                self.handleAutomation(pf, master, HASS, MINE, e['attributes'], name, g)
+            else:
+                self.handle_entity(pf, HASS, MINE, SAREF, class_to_saref, None, e['entity_id'], g, master)
+
+        # Print Turtle output both to console:
+        print(g.serialize(format='turtle'))
+        return g
+
+    def handleAutomation(self, pf, master, HASS, MINE, a, a_name, g):
+        logging.debug(f"Handling automation {a_name}...")
+        c_trigger = 0
+        a_o = MINE["automation/" + mkname(a_name)]
+        g.add((a_o, RDF.type, HASS['Automation']))
+        if hc.ATTR_FRIENDLY_NAME in a and (pf.privacy_filter is None or "automation" in pf.privacy_filter):
+            g.add((a_o, RDFS.label, Literal(a[hc.ATTR_FRIENDLY_NAME])))
+        # {'id': '1672829613487', 'alias': 'Floorheating BACK', 'description': '', 'trigger': [{'platform': 'time', 'at': 'input_datetime.floorheating_on'}], 'condition': [], 'action': [{'service': 'climate.set_temperature', 'data': {'temperature': 17}, 'target': {'device_id': 'ec5cb183f030a83754c6f402af08420f'}}], 'mode': 'single'}
+        if 'id' not in a:
+            logging.warning(f"Skipping automation {a_name} because it doesn't have an id.")
+            return  # Can't really proceed without a config here.
+        a_config = self.cs.getAutomationConfig(a['id'])
+        i = 0  # We'll number the container-elements
+        if 'action' in a_config:
+            the_actions = a_config['action']
+            assert 'actions' not in a_config
+        else:
+            the_actions = a_config['actions']
+
+        for an_action in the_actions:
+            # Convert back to its type:
+            try:
+                the_action = cv.determine_script_action(an_action)
+            except ValueError:
+                logging.error(f'Couldn\'t handle action {an_action}')
+                raise
+            # This call seems to perform some lifting, e.g. in cases where a one-element list
+            #  would be a single element in JSON, but the code would like to work with the list.
+            # assert cv.script_action(an_action) == an_action, (an_action, cv.script_action(an_action))
+            an_action = cv.script_action(an_action)
+            # TODO: assert HASS[the_action] already exists since we should have the schema.
+            # But no worky:
+            # assert hasEntity(master, Namespace("http://home-assistant.io/action/"), 'Action', the_action), the_action
+            o_action = HASS["action/" + the_action.title()]
+            o_action_instance = MINE["action/" + mkname(a_name) + "_" + str(i)]
+            g.add((o_action_instance, RDF.type, o_action))
+            g.add((a_o, HASS['consistsOf'], o_action_instance))  # TODO: XXX create multiplicity+order in schema
+            i = i + 1
+            if the_action == cv.SCRIPT_ACTION_CALL_SERVICE:
+                # TODO: use schema in Python...SERVICE_SCHEMA
+                # The big problem is that there are tons of modules bringing their own stuff where
+                #  HA essentially uses reflection at runtime to deal with them e.g. in the UI.
+                # If we want a stable static schema, the only way forward would be to try and integrate
+                #  INTO HA, and try to intercept schemata etc. when a plugin checks in on startup.
+                # It's unclear to me if that would work, and would require deeper digging.
+                #
+                # The cv.* below is what is prescribed by HA, and maybe we don't have to dig deeper
+                #  than `target`
+                # TODO: Everythign here is optional...
+                if cv.CONF_TARGET in an_action and cv.CONF_SERVICE in an_action:
+                    service_id = an_action[cv.CONF_SERVICE]
+                    target = an_action[cv.CONF_TARGET]
+                    self.process_target_schema(pf, HASS, MINE, g, o_action_instance, service_id, target)
+
+            elif the_action == cv.SCRIPT_ACTION_DEVICE_AUTOMATION:
+                # Schema prescribes only `device_id` and `domain`.
+                # https://www.home-assistant.io/integrations/device_automation/
+                device = pf.mkDevice(MINE, an_action[cv.CONF_DEVICE_ID])
+                g.add((o_action_instance, HASS['device'], device))
+
+                def button_action(config):
+                    e_id, _ = pf.mkEntityURI(MINE, an_action[cv.CONF_ENTITY_ID])
+                    g.add((o_action_instance, HASS['press'], e_id))
+
+                def climate_action(config):
+                    c = climate.device_action._ACTION_SCHEMA(config)
+                    # dispatch on ACTION_TYPE, assemble action based on entity/mode:
+                    _, e_name = ha.split_entity_id(c[hc.CONF_ENTITY_ID])
+                    name = mkname(e_name) + "_" + c[hc.CONF_TYPE]
+                    # TODO: should be intermediate object? Or subclassing?
+                    my_service = MINE["service/" + name.title()]
+                    g.add((o_action_instance, HASS['target'], my_service))
+                    # Modelling happening here:
+                    g.add((my_service, RDFS.subClassOf, HASS["Climate_Mode"]))
+                    if c[hc.CONF_TYPE] == "set_hvac_mode":
+                        mode = c[climate.ATTR_HVAC_MODE]
+                        # Sloppy, should be enum:
+                        g.add((my_service, HASS['mode'], Literal(mode)))
+                    elif c[hc.CONF_TYPE] == "set_preset_mode":
+                        mode = c[climate.ATTR_PRESET_MODE]
+                        g.add((my_service, HASS['mode'], Literal(mode)))
+                    else:
+                        logging.fatal(f"Action Oops: {c}.")
+                    pass
+
+                def toggle_action(config):
+                    # Obs: we can't call the toggle_entity-schema validator, since the action
+                    #   may have contributed new things.
+                    c = config  # device_automation.toggle_entity.ACTION_SCHEMA(config)
+
+                    if c[hc.CONF_TYPE] in device_automation.toggle_entity.DEVICE_ACTION_TYPES:
+                        _, e_name = ha.split_entity_id(c[cv.CONF_ENTITY_ID])
+                        name = mkname(e_name) + "_" + c[hc.CONF_TYPE]
+                        # assert hasEntity(master, Namespace("http://my.name.spc/service/"), 'Service', name) is not None, name
+                        # TODO: Why "service", not "action"?
+                        g.add((o_action_instance, HASS['target'], MINE["service/" + name]))
+                    else:
+                        # Not for us here.
+                        pass
+                    return c[cv.CONF_ENTITY_ID], c[hc.CONF_TYPE]
+
+                def light_action(config):
+                    # "Inherits" from device_automation/toggle_entity
+                    e_id, type = toggle_action(config)
+                    opt_flash = config[light.device_action.ATTR_FLASH] if light.device_action in config else None
+                    opt_bright_pct = config[light.device_action.ATTR_BRIGHTNESS_PCT] if light.device_action in config else None
+                    # TODO: Can model here! It looks like that you can set DECREASE and still set PCT > 10 :-)
+                    if type == light.device_action.TYPE_BRIGHTNESS_DECREASE:
+                        # default: -10
+                        # TODO: Review with Fernando
+                        # TODO: superclass + attributes
+                        g.remove((o_action_instance, RDF.type, None))
+                        g.add((o_action_instance, RDF.type, HASS['action/LIGHT_ACTION_CHANGE_BRIGHTNESS']))
+                        g.add((o_action_instance, HASS['changeBrightnessBy'], Literal(opt_bright_pct if opt_bright_pct is not None else -10)))
+                    elif type == light.device_action.TYPE_BRIGHTNESS_INCREASE:
+                        # default: +10
+                        g.remove((o_action_instance, RDF.type, None))
+                        g.add((o_action_instance, RDF.type, HASS['action/LIGHT_ACTION_CHANGE_BRIGHTNESS']))
+                        g.add((o_action_instance, HASS['changeBrightnessBy'], Literal(opt_bright_pct if opt_bright_pct is not None else 10)))
+                    elif type == light.device_action.TYPE_FLASH:
+                        # default = short according to source.
+                        g.remove((o_action_instance, RDF.type, None))
+                        g.add((o_action_instance, RDF.type, HASS['action/LIGHT_ACTION_FLASH']))
+                        g.add((o_action_instance, HASS['flashLength'], Literal(opt_flash if opt_flash is not None else "short")))
+                    else:
+                        # TODO: Lift "toggle".
+                        logging.fatal(f"Unsupported type in: {config}")
+
+                action_table = {
+                    hc.Platform.BINARY_SENSOR: None,
+                    hc.Platform.BUTTON: (button.device_action._ACTION_SCHEMA, button_action),
+                    hc.Platform.CLIMATE: (climate.device_action._ACTION_SCHEMA, climate_action),
+                    # hc.Platform.FAN: (fan.device_action.ACTION_SCHEMA, fan_action),
+                    hc.Platform.LIGHT: (light.device_action._ACTION_SCHEMA, light_action),
+                    hc.Platform.SENSOR: None,
+                    hc.Platform.SWITCH: (switch.device_action._ACTION_SCHEMA, toggle_action),  # Nothing more.
+                }
+                if an_action[cv.CONF_DOMAIN] not in action_table:
+                    logging.error(f"Skipping action domain {an_action[cv.CONF_DOMAIN]}.")
+                else:
+                    schema, action = action_table[an_action[cv.CONF_DOMAIN]]
+                    if action is not None:
+                        # And off we go!
+                        action(schema(an_action))
+            elif the_action == cv.SCRIPT_ACTION_DELAY:
+                g.add((o_action_instance, HASS['delay'],  # sloppy
+                       Literal(str(cv.time_period(an_action[cv.CONF_DELAY])))))
+            else:
+                logging.warning("Skipping action " + the_action + ":" + str(an_action))  # TODO
+            # TODO: populate schema by action type
+            # `action`s are governed by: https://github.com/home-assistant/core/blob/31a787558fd312331b55e5c2c4b33341fc3601fc/homeassistant/helpers/script.py#L270
+            # After that it's following the `_SCHEMA`
+        if 'trigger' in a_config:
+            the_triggers = a_config['trigger']
+            assert 'triggers' not in a_config
+        else:
+            the_triggers = a_config['triggers']
+        for a_trigger in the_triggers:
+            # https://www.home-assistant.io/docs/automation/trigger/
+            for t in cv.TRIGGER_SCHEMA(a_trigger):
+                # Only `platform` is mandatory.
+                c_trigger = c_trigger + 1
+                if not any(x for x in hc.Platform if x.name == t[cv.CONF_PLATFORM]):
+                    # These are some built-ins:
+                    logging.debug(f"Checking platform `{t[cv.CONF_PLATFORM]}`")
+                    if not t[cv.CONF_PLATFORM] in _PLATFORM_ALIASES:
+                        logging.info(f"Found custom platform `{t[cv.CONF_PLATFORM]}`")
+
+                o_trigger = MINE["trigger/" + a_name + str(c_trigger)]
+                o_platform = HASS["platform/" + t[cv.CONF_PLATFORM].title()]
+                o_platform_i = MINE[t[cv.CONF_PLATFORM].title()+"_platform"]
+                g.add((o_platform_i, HASS["providesTrigger"], o_trigger))
+                g.add((o_platform_i, RDF.type, o_platform))
+                g.add((o_platform, RDFS.subClassOf, HASS['platform/Platform']))
+
+                e_ids = t['entity_id'] if 'entity_id' in t else None
+                if e_ids is not None:
+                    # https://www.home-assistant.io/docs/automation/trigger/#multiple-entity-ids-for-the-same-trigger
+                    # TODO: isn't there a schema that should list this for us?
+                    if isinstance(e_ids, list):
+                        assert len(e_ids) > 0
+                    else:
+                        e_ids = [e_ids]
+                    for e_id in e_ids:
+                        try:
+                            # This may fail, e.g. here:
+                            # DEBUG: {'platform': 'device', 'device_id': '496ce175a3ff16bbb214ea878c416683', 'domain': 'media_player', 'entity_id': '1602326a3170faf6e836fba047b5a866', 'type': 'playing'}
+                            trigger_entity, _ = pf.mkEntityURI(MINE, e_id)
+                            g.add((o_trigger, HASS['trigger_entity'], trigger_entity))
+                        except ValueError:
+                            # logged upstream already
+                            pass
+
+                # Still a bit unclear here. An Action Trigger schema is very general,
+                #  whereas the concrete schemas like binary_sensor/device_trigger.py prescribe more elements,
+                #  most importantly `entity_id`
+                if t[cv.CONF_PLATFORM] == "device":
+                    trigger_device = pf.mkDevice(MINE, t[hc.CONF_DEVICE_ID])
+                    g.add((o_trigger, HASS['device'], trigger_device))
+                    # We just pick up anything via reflection here without looking into it.
+                    trigger_type = HASS["type/" + t[hc.CONF_TYPE].title()]  # TODO: static? May not be possible/effective,
+                    # ...since there's no global super-container? This must be INSIDE Homeassistant! #5
+                    # What I don't know is if the triggers etc. are installed even though you're not using the integration...
+                    g.add((trigger_type, RDFS.subClassOf, HASS["type/TriggerType"]))
+                    g.add((o_trigger, RDF.type, trigger_type))
+                elif t[cv.CONF_PLATFORM] == zone.const.DOMAIN:
+                    e_id = t[hc.CONF_ENTITY_ID]  # already done
+                    e_zone = t[hc.CONF_ZONE]
+                    o_zone, _ = pf.mkEntityURI(MINE, e_zone)
+                    e_event = t[hc.CONF_EVENT]
+                    trigger_type = HASS["type/ZoneTrigger"]
+                    g.add((o_trigger, RDF.type, trigger_type))
+                    self.mkDirectAttribute(HASS, hc.CONF_EVENT, g, o_trigger, t)
+                    g.add((o_trigger, HASS['zone'], o_zone))
+                elif t[hc.CONF_PLATFORM] == "state":
+                    trigger_type = HASS["type/StateTrigger"]
+                    g.add((o_trigger, RDF.type, trigger_type))
+                    g.add((o_trigger, HASS['from'], Literal(t['from'])))
+                    g.add((o_trigger, HASS['to'], Literal(t['to'])))
+                elif t[hc.CONF_PLATFORM] == "numeric_state":
+                    trigger_type = HASS["type/NumericStateTrigger"]
+                    g.add((o_trigger, RDF.type, trigger_type))
+                    #             vol.Required(CONF_PLATFORM): "numeric_state",
+                    #             vol.Required(CONF_ENTITY_ID): cv.entity_ids_or_uuids,
+                    #             vol.Optional(CONF_BELOW): cv.NUMERIC_STATE_THRESHOLD_SCHEMA,
+                    #             vol.Optional(CONF_ABOVE): cv.NUMERIC_STATE_THRESHOLD_SCHEMA,
+                    #             vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+                    #             vol.Optional(CONF_FOR): cv.positive_time_period_template,
+                    #             vol.Optional(CONF_ATTRIBUTE): cv.match_all,
+                    self.mkDirectAttribute(HASS, hc.CONF_ABOVE, g, o_trigger, t)
+                    self.mkDirectAttribute(HASS, hc.CONF_BELOW, g, o_trigger, t)
+                    self.mkDirectAttribute(HASS, hc.CONF_ATTRIBUTE, g, o_trigger, t)
+                elif t[cv.CONF_PLATFORM] == sun.const.DOMAIN:
+                    e_event = t[hc.CONF_EVENT]
+                    offset = t[hc.CONF_OFFSET]
+                    trigger_type = HASS["type/SunTrigger"]
+                    g.add((o_trigger, RDF.type, trigger_type))
+                    self.mkDirectAttribute(HASS, hc.CONF_EVENT, g, o_trigger, t)
+                    self.mkDirectAttribute(HASS, hc.CONF_OFFSET, g, o_trigger, t)
+                elif t[cv.CONF_PLATFORM] == "mqtt":
+                    #         vol.Required(CONF_PLATFORM): mqtt.DOMAIN,
+                    #         vol.Required(CONF_TOPIC): mqtt.util.valid_subscribe_topic_template,
+                    #         vol.Optional(CONF_PAYLOAD): cv.template,
+                    #         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+                    #         vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
+                    #         vol.Optional(CONF_QOS, default=DEFAULT_QOS): vol.All(
+                    #             vol.Coerce(int), vol.In([0, 1, 2])
+                    #         ),
+                    trigger_type = HASS["type/MQTTTrigger"]
+                    g.add((o_trigger, RDF.type, trigger_type))
+                    self.mkDirectAttribute(HASS, mqtt.device_trigger.CONF_TOPIC, g, o_trigger, t)
+                else:
+                    logging.warning(f"not handling trigger platform {t[cv.CONF_PLATFORM]}: {t}.")
+                    g.add((o_trigger, RDF.type, HASS[f"trigger/{t[cv.CONF_PLATFORM].title()}"]))
+                    g.add((HASS[f"trigger/{t[cv.CONF_PLATFORM].title()}"], RDFS.subClassOf, HASS['type/TriggerType']))
+                    continue
+                # TODO: investigate warning on line below
+                g.add((a_o, HASS['hasTrigger'], o_trigger))
+
+        if 'condition' in a_config:
+            the_conditions = a_config['condition']
+            assert 'conditions' not in a_config
+        else:
+            the_conditions = a_config['conditions']
+        for a_condition in the_conditions:
+            for c in cv.CONDITION_SCHEMA(a_condition):
+                pass  # TODO
+
+    def mkDirectAttribute(self, HASS, attribute, g, o_trigger, t):
+        if attribute in t:
+            g.add((o_trigger, HASS[attribute], Literal(t[attribute])))
+
+    def process_target_schema(self, pf, HASS, MINE, g, o_action_instance, service_id, target):
+        # TODO: The HASS['target'] here have no common superclass.
+        if cv.ATTR_ENTITY_ID in target:
+            for e in target[cv.ATTR_ENTITY_ID]:
+                # This is a little bit tricky where we diverge from HA's modelling:
+                #  We have a concrete instance already which corresponds to this particular pair of `service, target`.
+                _, t_name = ha.split_entity_id(e)
+                _, service_name = ha.split_entity_id(service_id)
+                target_entity = MINE["service/" + mkname(t_name) + "_" + service_name]
+                g.add((o_action_instance, HASS['target'], target_entity))
+        if cv.ATTR_DEVICE_ID in target:
+            for d in target[cv.ATTR_DEVICE_ID]:
+                target_device = pf.mkDevice(MINE, d)
+                g.add((o_action_instance, HASS['target'], target_device))
+        if cv.ATTR_AREA_ID in target:
+            # untested:
+            for a in target[cv.ATTR_AREA_ID]:
+                target_area = pf.mkLocationURI(MINE, a)
+                g.add((o_action_instance, HASS['target'], target_area))
+
+    @staticmethod
+    def mkServiceURI(MINE, SAREF, service_id):
+        _, service_name = ha.split_entity_id(service_id)
+        if service_name == hc.SERVICE_TURN_ON:  # dupe TODO
+            e_service_instance = SAREF["SwitchOnService"]
+        else:
+            e_service_instance = MINE["service/" + mkname(service_name.title()) + "_service"]
+        return e_service_instance
+
+    def handle_entity(self, pf, HASS, MINE, SAREF, class_to_saref, device: Optional[str], e, g, master):
+        logging.info(f"Handling {e} for device {device}.")
+        assert e.count('.') == 1
+        (domain, e_name) = ha.split_entity_id(e)
+        # Experimental section:
+        # e_friendly_name = getYAML(f'state_attr("{e}", "friendly_name")')
+        # END
+        attrs = self.cs.getAttributes(e)
+        device_class = attrs['device_class'] if 'device_class' in attrs else None
+        e_d = None
+        # if device is not None and domain not in class_to_saref:
+        if domain not in class_to_saref:
+            if device is None:
+                c = HASS["platform/"+domain.title()]  # TODO: Review
+                g.add((c, RDFS.subClassOf, HASS['platform/Platform']))
+            else:
+                # TODO
+                c = SAREF['Device']
+        else:
+            c = class_to_saref[domain]
+            # Nope out if `None`. Otherwise, use `domain` to instantiate, and remember the super-class (RHS) for later.
+            if c is None:
+                logging.warning(f"Skipping {e} (no mapping for domain {domain}).")
+                return None  # Tell upstream.
+            (subclass, super_class) = c
+            if subclass:
+                c = HASS[domain.title()]
+            else:
+                c = super_class
+            if super_class == SAREF['Sensor']:  # XXX?
+                # Special-casing (business rule):
+                if device_class == SensorDeviceClass.TEMPERATURE:
+                    c = SAREF["TemperatureSensor"]
+                    # assert attrs['state_class'] == "measurement", attrs
+                elif device_class == SensorDeviceClass.HUMIDITY:
+                    # TODO. Do we want more subclasses here?
+                    pass
+                    # c = HASS['HumiditySensor']
+                    # assert attrs['state_class'] == "measurement", attrs
+                elif device_class == SensorDeviceClass.ENERGY:
+                    c = SAREF['Meter']
+                    # TODO -- probably we shouldn't be asserting those things.
+                    # assert attrs['state_class'] == "total_increasing", attrs
+                else:
+                    # Spam:
+                    if device_class is not None:
+                        logging.warning(f"Not handling class {device_class} for {e} (yet).")
+                # END
+        # https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/entity_registry.py
+        e_d, e_name = pf.mkEntityURI(MINE, e)
+        g.add((e_d, RDF.type, c))
+        try:
+            friendly_name = self.cs.getAttributes(e)[hc.ATTR_FRIENDLY_NAME]
+            if pf.privacy_filter is None or e_d in pf.privacy_filter:
+                # Bad idea, but...:
+                g.add((e_d, RDFS.label, Literal(friendly_name)))
+        except KeyError:
+            pass
+
+        # We're creating this reference to maybe analyse the mapping to SAREF later.
+        #  Maybe the name or NS should be more outstanding? The interesting cases are
+        # where the type is in HA and not a trivial subclass of SAREF:Device, or where
+        # multiple platforms are projected onto the same SAREF Device.
+        # TODO: Check with Fernando if this single instance here is an anti-pattern.
+        # Or is our superclass like hass:Zone good enough?
+        # Create instance (is MINE a good choice here?):
+        g.add((MINE[domain.title() + "_platform"], RDF.type, HASS['platform/' + domain.title()]))
+        g.add((e_d, HASS['provided_by'], MINE[domain.title() + "_platform"]))
+
+        # Look up services this domain should have, and create them for this entity.
+        features = attrs['supported_features'] if 'supported_features' in attrs else {}
+        if domain in self.cs.getServices():
+            for service in self.cs.getServices()[domain]:
+                skip = False
+
+                if domain == hc.Platform.BUTTON:
+                    pass
+                elif domain == hc.Platform.CLIMATE:
+                    skip = service == climate.const.SERVICE_SET_FAN_MODE and not features & climate.ClimateEntityFeature.FAN_MODE
+                    skip |= service == climate.const.SERVICE_SET_HUMIDITY and not features & climate.ClimateEntityFeature.TARGET_HUMIDITY
+                    skip |= service == climate.const.SERVICE_SET_PRESET_MODE and not features & climate.ClimateEntityFeature.PRESET_MODE
+                    skip |= service == climate.const.SERVICE_SET_SWING_MODE and not features & climate.ClimateEntityFeature.SWING_MODE
+                elif domain == hc.Platform.DEVICE_TRACKER:
+                    pass
+                elif domain == hc.Platform.REMOTE:
+                    skip = service == remote.SERVICE_LEARN_COMMAND and not features & remote.RemoteEntityFeature.LEARN_COMMAND
+                    skip |= service == remote.SERVICE_DELETE_COMMAND and not features & remote.RemoteEntityFeature.DELETE_COMMAND
+                    # TODO: What about remote.RemoteEntityFeature.ACTIVITY?
+                elif domain == hc.Platform.LIGHT:
+                    # Unclear how to handle light.LightEntityFeature.FLASH -- affects just args?
+                    pass
+                else:
+                    pass  # TODO
+                if skip:
+                    continue
+                # Silly mapping, also see below.
+                if service == hc.SERVICE_TURN_ON:
+                    s_class = SAREF["SwitchOnService"]
+                else:
+                    s_class = HASS["service/" + service.title()]
+                # TODO: constructed name is ... meh...
+                HACVT.serviceOffer(MINE, SAREF, e_d, e_name, g, "_" + service, s_class)
+
+        # This part here maps HA platforms to SAREF-Device types.
+        # Some HASS entities we can map to SAREF, others we just carry around inheriting
+        #  from hass:Platform, because we can't  if they are saref:Devices. Or are they always?
+        if domain == hc.Platform.SWITCH:
+            # TODO: review double-typing.
+            g.add((e_d, RDF.type, SAREF['Sensor']))  # because it would send notifications/"measure" the current setting?
+            # e_function = MINE[mkname(e_name)+"_function"]  # TODO: name?
+            # g.add((e_function, RDF.type, SAREF['OnOffFunction']))
+            # g.add((e_d, SAREF['hasFunction'], e_function))
+            pass
+        elif domain == hc.Platform.BUTTON:
+            pass  # OK, nothing in there.
+        elif domain == hc.Platform.CLIMATE:
+            # Business rule: https://github.com/home-assistant/core/blob/dev/homeassistant/components/climate/__init__.py#L214
+            # Are we delivering temperature readings, e.g. an HVAC?
+            # TODO: Don't use double-typing, but add sub-devices to parent?
+            q = attrs[climate.ATTR_CURRENT_TEMPERATURE] if 'current_temperature' in attrs else None
+            if q is not None:
+                g.add((e_d, RDF.type, SAREF['TemperatureSensor']))
+            q = attrs[climate.ATTR_CURRENT_HUMIDITY] if 'current_humidity' in attrs else None
+            if q is not None:
+                g.add((e_d, RDF.type, HASS['HumiditySensor']))
+            # END
+        elif domain == hc.Platform.BINARY_SENSOR or domain == hc.Platform.SENSOR:  # Handle both types in one for now.
+            if device_class is not None:
+                q_o = self.createPropertyIfMissing(master, HASS, SAREF, g, device_class.title())
+                # ...and instance:
+                # TODO: should this be shared, ie. do we want different sensor measuring the same property?
+                q_prop = MINE[f"{device_class.title()}_prop"]
+                g.add((q_prop, RDF.type, q_o))
+                g.add((e_d, SAREF['measuresProperty'], q_prop))
+            #
+            q = attrs['unit_of_measurement'] if 'unit_of_measurement' in attrs else None
+            if q is not None:
+                # TODO - more below. When is this complete? When we've either exhausted SAREF or HASS.
+                if device_class == SensorDeviceClass.TEMPERATURE:
+                    unit = SAREF['TemperatureUnit']
+                elif device_class == SensorDeviceClass.CURRENT:
+                    unit = SAREF['PowerUnit']
+                elif device_class == SensorDeviceClass.POWER:
+                    unit = SAREF['PowerUnit']
+                elif device_class == SensorDeviceClass.ENERGY:
+                    unit = SAREF['EnergyUnit']
+                elif device_class == SensorDeviceClass.PRESSURE:
+                    unit = SAREF['PressureUnit']
+                else:  # Not built-in.
+                    # TODO: check -- are we done here?
+                    # Should get them from HA core statically. (#5)
+                    unit = HASS[mkname(q)]
+                    g.add((unit, RDFS.subClassOf, SAREF['UnitOfMeasure']))
+                    # TODO: add Measurement/Property
+                g.add((MINE[mkname(q)], RDF.type, unit))
+        elif domain == hc.Platform.LIGHT:
+            pass  # Ok
+        elif domain == hc.Platform.WEATHER:
+            # TODO: Loooots of attributes
+            pass
+        else:
+            logging.warning(f"not really handling platform {domain}/{e}.")
+        return e_d
+
+    def createPropertyIfMissing(self, master, HASS, SAREF, g, q):
+        # Let's look it up in the SAREF "master-list":
+        q_o = self.hasEntity(master, SAREF, 'Property', q)
+        # TODO: we don't find the ones that we've already created ourselves,
+        #  even in `g` that way!
+        if not (q_o is None):
+            return q_o
+        q_o = HASS[q]
+        uri = URIRef("http://home-assistant.io/" + q)
+        # TODO: is this worth the effort?
+        if len(list(g.triples((uri, None, None)))) == 0:
+            logging.info(f"Creating {q}.")
+            # Create Property...
+            g.add((q_o, RDFS.subClassOf, SAREF['Property']))
+        return q_o
+
+    @staticmethod
+    def serviceOffer(MINE, SAREF, e_d, e_name, g, suffix, svc_obj):
+        e_service_inst = MINE["service/" + mkname(e_name) + suffix]
+        g.add((e_service_inst, RDF.type, svc_obj))
+        g.add((e_d, SAREF['offers'], e_service_inst))
+
+    def getEntitiesWODevice(self):
+        for k in self.cs.getStates():
+            # Weird...you'd think they'd care 'device_id' around, but they don't:
+            if self.cs.getDeviceId(k['entity_id']) == 'None':
+                yield k
+
+    def mkServiceToDomainTable(self):
+        hass_svcs = {}
+        for component_name, svc_services in self.cs.getServices().items():
+            for s in svc_services:
+                if s in hass_svcs:
+                    t = hass_svcs[s]
+                    t.add(component_name)
+                    hass_svcs[s] = t
+                else:
+                    hass_svcs[s] = {component_name}
+        return hass_svcs
+
+    @staticmethod
+    @cache
+    def hasEntity(graph, ns, cl, q):
+        # TODO: At least we're caching now...but we could precompute a dictionary.
+        # Can't search in e.g. HA_ACTION?
+        for s, _, _ in graph.triples((None, RDFS.subClassOf, ns[cl])):
+            if s.endswith("/" + q):
+                return ns[q]
+        return None
+
+    def setupSAREF(self, g, namespace, importsOnly=False):
+        SAREF = Namespace("https://saref.etsi.org/core/")
+        S4BLDG = Namespace("https://saref.etsi.org/saref4bldg/")
+        HASS = Namespace("https://www.foldr.org/profiles/homeassistant/")
+        HASS_ACTION = HASS.term("action/")
+        HASS_BLUEPRINT = HASS.term("blueprint/")
+        g.bind("saref", SAREF)
+        g.bind("owl", OWL)
+        g.bind("s4bldg", S4BLDG)
+        g.bind("hass", HASS)
+        g.bind("ha_action", HASS_ACTION)
+        g.bind("ha_bp", HASS_BLUEPRINT)
+        MINE = Namespace(namespace)
+        MINE_ACTION = MINE.term("action/")
+        MINE_AUTOMATION = MINE.term("automation/")
+        MINE_ENTITY = MINE.term("entity/")
+        MINE_SERVICE = MINE.term("service/")
+        if importsOnly:
+            saref_import = URIRef(str(MINE))
+        else:
+            saref_import = URIRef(str(HASS))
+        g.add((saref_import, RDF.type, OWL.Ontology))
+        g.add((saref_import, OWL.imports, URIRef(str(SAREF))))
+        g.add((saref_import, OWL.imports, URIRef(str(S4BLDG))))
+
+        # Load known types:
+        master = Graph()
+        master.parse("https://saref.etsi.org/core/v3.1.1/saref.ttl")
+
+        if importsOnly:
+            return MINE, HASS, SAREF, S4BLDG, None, master
+
+        g.bind("mine", MINE)
+        g.bind("action", MINE_ACTION)
+        g.bind("automation", MINE_AUTOMATION)
+        g.bind("entity", MINE_ENTITY)
+        g.bind("service", MINE_SERVICE)
+
+        # Experimental
+        # Manual entities, e.g. from "lights":
+
+        # TODO: light maybe_has brightness?
+        g.add((HASS['Brightness'], RDFS.subClassOf, SAREF['Property']))
+        # TODO: Some need alignment with SAREF! #11
+        for p in homeassistant.components.sensor.SensorDeviceClass:
+            self.createPropertyIfMissing(master, HASS, SAREF, g, p.title())
+        for p in homeassistant.components.binary_sensor.BinarySensorDeviceClass:
+            self.createPropertyIfMissing(master, HASS, SAREF, g, p.title())
+
+        # Inject Service-classes
+        # Note that using /api/services only gives you the services of your instance. Here, we want to create
+        #  the metamodel/profile for HA, so we should use data from a git-checkout...
+        # We still need a static map to SAREF.
+
+        hass_svcs = self.mkServiceToDomainTable()
+        for s, domains in hass_svcs.items():
+            # This is weird: SAREF has SwitchOnService -- only:
+            if s == hc.SERVICE_TURN_ON:
+                continue  # special case...
+            g.add((HASS["service/" + s.title()], RDFS.subClassOf, SAREF['Service']))
+            # WIP -- do we want to inject ALL HASS classes below the corresponding SAREF devices?
+            # for d in domains:
+            #    print(s,d)
+            #    g.add((HASS[s], MINE['provided'], HASS[d]))
+
+        # Let's patch SAREF a bit with our extensions:
+        # True/False could be replaced by having the HASS-ns on the RHS.
+        class_to_saref = {
+            hc.Platform.AIR_QUALITY: (True, SAREF["Sensor"]),
+            hc.Platform.ALARM_CONTROL_PANEL: (True, SAREF["Device"]),
+            hc.Platform.BINARY_SENSOR: (False, SAREF["Sensor"]),  # Modelling design decisions...
+            hc.Platform.BUTTON: (True, SAREF["Sensor"]),
+            hc.Platform.CALENDAR: None,
+            hc.Platform.CAMERA: (True, SAREF["Device"]),
+            hc.Platform.CLIMATE: (False, SAREF["HVAC"]),
+            hc.Platform.COVER: (True, SAREF["Actuator"]),  # ? saref4bldg:ShadingDevice
+            hc.Platform.DEVICE_TRACKER: (True, SAREF["Sensor"]),
+            hc.Platform.FAN: (True, SAREF["Appliance"]),
+            hc.Platform.GEO_LOCATION: None,
+            hc.Platform.HUMIDIFIER: (True, SAREF["Appliance"]),
+            hc.Platform.IMAGE_PROCESSING: None,
+            hc.Platform.LIGHT: (True, SAREF["Appliance"]),
+            hc.Platform.LOCK: (True, SAREF["Appliance"]),
+            # XXX Deprecated hc.Platform.MAILBOX: None,
+            hc.Platform.MEDIA_PLAYER: (True, SAREF["Appliance"]),
+            hc.Platform.NOTIFY: None,
+            hc.Platform.NUMBER: None,  # SERVICE_SET_VALUE
+            hc.Platform.REMOTE: (True, SAREF["Device"]),
+            hc.Platform.SCENE: None,
+            hc.Platform.SELECT: None,  # SERVICE_SELECT_OPTION
+            hc.Platform.SENSOR: (False, SAREF["Sensor"]),
+            hc.Platform.SIREN: (True, SAREF["Appliance"]),
+            hc.Platform.STT: None,
+            hc.Platform.SWITCH: (False, SAREF["Switch"]),  # Modelling.
+            hc.Platform.TEXT: None,
+            hc.Platform.TTS: None,
+            hc.Platform.UPDATE: None,
+            hc.Platform.VACUUM: (True, SAREF["Appliance"]),
+            hc.Platform.WATER_HEATER: (True, SAREF["Appliance"]),
+            hc.Platform.WEATHER: (True, SAREF["Sensor"]),
+            # Not a `platform`:
+            "device": (False, SAREF["Device"]),  # of course...
+        }
+        for p, v in class_to_saref.items():
+            if v is not None:
+                flag, superclass = v
+                if flag:
+                    g.add((HASS[p.title()], RDFS.subClassOf, superclass))
+        # END
+
+        # Proper HASS-contribution to SAREF:
+        # TODO: Review with Fernando -- we could introduce HASS['Entity'] and double-type.
+        prop = HASS['via_device']
+        g.add((prop, RDF.type, OWL.ObjectProperty))
+        g.add((prop, RDFS.domain, SAREF['Device']))
+        g.add((prop, RDFS.range, SAREF['Device']))
+        #
+
+        # BEGIN SCHEMA metadata, reflection on
+        #  https://github.com/home-assistant/core/blob/9f7fd8956f22bd873d14ae89460cdffe6ef6f85d/homeassistant/helpers/config_validation.py#L1641
+        ha_action = HASS['action/Action']
+        # Automation consistsOf (order) Actions
+        h_prov = HASS['consistsOf']
+        g.add((h_prov, RDF.type, OWL.ObjectProperty))
+        g.add((h_prov, OWL.inverseOf, HASS['belongsTo']))
+        g.add((h_prov, RDFS.domain, HASS['Automation']))
+        g.add((h_prov, RDFS.range, ha_action))
+        for k, v in cv.ACTION_TYPE_SCHEMAS.items():
+            g.add((HASS["action/" + k.title()], RDFS.subClassOf, ha_action))
+        # END
+
+        # Blueprints
+        # Consider if we want this here in the HA-MM...
+        h_bp = HASS['blueprint/Blueprint']
+        h_bp_input = HASS['blueprint/Input']
+        h_bp_has_inputs = HASS['blueprint/hasInputs']
+        g.add((h_bp_has_inputs, RDF.type, OWL.ObjectProperty))
+        g.add((h_bp_has_inputs, RDFS.domain, h_bp))
+        g.add((h_bp_has_inputs, RDFS.range, h_bp_input))
+        h_bp_selector = HASS['blueprint/Selector']
+        h_input_has_selector = HASS['blueprint/hasSelector']
+        g.add((h_input_has_selector, RDF.type, OWL.ObjectProperty))
+        g.add((h_input_has_selector, RDFS.domain, h_bp_input))
+        g.add((h_input_has_selector, RDFS.range, h_bp_selector))
+        for s in homeassistant.helpers.selector.SELECTORS:
+            g.add((HASS['blueprint/'+s.title()], RDFS.subClassOf, h_bp_selector))
+
+        bp_e = HASS['blueprint/Selector_Entity']  # ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA
+        # TODO: turn strings into references?
+        prop_has_entity = HASS['blueprint/Selector_Entity_Integration']
+        g.add((prop_has_entity, RDF.type, OWL.DatatypeProperty))
+        g.add((prop_has_entity, RDFS.domain, bp_e))
+        g.add((prop_has_entity, RDFS.range, XSD.string))  # TODO: just one
+        prop_has_entity = HASS['blueprint/Selector_Entity_Domain']
+        g.add((prop_has_entity, RDF.type, OWL.DatatypeProperty))
+        g.add((prop_has_entity, RDFS.domain, bp_e))
+        g.add((prop_has_entity, RDFS.range, HASS['platform/Platform']))  # Many
+        prop_has_entity = HASS['blueprint/Selector_Entity_DeviceClass']  # TODO: Didn't model those yet?
+        g.add((prop_has_entity, RDF.type, OWL.DatatypeProperty))
+        g.add((prop_has_entity, RDFS.domain, bp_e))
+        g.add((prop_has_entity, RDFS.range, XSD.string))  # Many
+
+        # exit(1)
+        # END Blueprints
+
+        tt = HASS["type/TriggerType"]
+        prop_has_trigger = HASS['hasTrigger']
+        g.add((prop_has_trigger, RDF.type, OWL.ObjectProperty))
+        g.add((prop_has_trigger, RDFS.domain, HASS['Automation']))
+        g.add((prop_has_trigger, RDFS.range, tt))
+
+        prop_has_entity = HASS['trigger_entity']
+        g.add((prop_has_entity, RDF.type, OWL.ObjectProperty))
+        g.add((prop_has_entity, RDFS.domain, tt))
+        g.add((prop_has_entity, RDFS.range, SAREF['Device']))
+
+        trigger_type = HASS["type/NumericStateTrigger"]
+        g.add((trigger_type, RDFS.subClassOf, HASS["type/TriggerType"]))
+        trigger_type = HASS["type/MQTTTrigger"]
+        g.add((trigger_type, RDFS.subClassOf, HASS["type/TriggerType"]))
+
+        trigger_type = HASS["type/StateTrigger"]
+        g.add((trigger_type, RDFS.subClassOf, HASS["type/TriggerType"]))
+        for prop in ['from', 'to']:
+            prop_has_entity = HASS[prop]
+            g.add((prop_has_entity, RDF.type, OWL.DatatypeProperty))
+            g.add((prop_has_entity, RDFS.domain, trigger_type))
+            g.add((prop_has_entity, RDFS.range, XSD.string))
+
+        zt = HASS["type/ZoneTrigger"]
+        g.add((zt, RDFS.subClassOf, tt))
+        # TODO: Uhhh...forgot?
+        # prop = HASS['event']
+        # g.add((prop, RDF.type, OWL.DatatypeProperty))
+        # g.add((zt, RDFS.subClassOf, prop))
+        prop = HASS['zone']
+        g.add((prop, RDF.type, OWL.ObjectProperty))
+        g.add((prop, RDFS.domain, zt))
+        g.add((prop, RDFS.range, SAREF['Device']))
+
+        st = HASS["type/SunTrigger"]
+        g.add((st, RDFS.subClassOf, tt))
+        # Event, Offset
+
+        # Model platforms -- unclear if we'll really need this in the future,
+        #  but useful for i) a complete metamodel ii) for cross-referencing.
+        ha_platform = HASS['platform/Platform']
+        h_platform_provides_triggers = HASS["providesTrigger"]
+        g.add((h_platform_provides_triggers, RDFS.domain, ha_platform))
+        g.add((h_platform_provides_triggers, RDFS.range, HASS['type/TriggerType']))
+
+        h_prov = HASS['provided_by']
+        g.add((h_prov, RDF.type, OWL.ObjectProperty))
+        g.add((h_prov, OWL.inverseOf, HASS['provides']))
+        # Actually, a HASS-entity! REVIEW, must be subclass of saref:device in hass-ns!
+        # TODO: Talk with Fernando about this.
+        g.add((h_prov, RDFS.domain, SAREF['Device']))
+        g.add((h_prov, RDFS.range, ha_platform))
+
+        for p in hc.Platform:
+            g.add((HASS['platform/' + p.title()], RDFS.subClassOf, ha_platform))
+        # END
+
+        # Actions
+        # This are manually from /lights, which has these actions but not services.
+        g.add((HASS['action/LIGHT_ACTION_CHANGE_BRIGHTNESS'], RDFS.subClassOf, HASS['action/Device']))
+        prop_has_entity = HASS['changeBrightnessBy']
+        g.add((prop_has_entity, RDF.type, OWL.DatatypeProperty))
+        g.add((prop_has_entity, RDFS.domain, HASS['action/LIGHT_ACTION_CHANGE_BRIGHTNESS']))
+        g.add((prop_has_entity, RDFS.range, XSD.string))  # Can't be bothered to find out if int or float.
+
+        g.add((HASS['action/LIGHT_ACTION_FLASH'], RDFS.subClassOf, HASS['action/Device']))
+        prop_has_entity = HASS['flashLength']
+        g.add((prop_has_entity, RDF.type, OWL.DatatypeProperty))
+        g.add((prop_has_entity, RDFS.domain, HASS['action/LIGHT_ACTION_FLASH']))
+        g.add((prop_has_entity, RDFS.range, XSD.boolean))  # long/short
+
+        # END
+        return MINE, HASS, SAREF, S4BLDG, class_to_saref, master
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--debug', default='INFO', const='DEBUG', nargs='?',
+                        help="Set Python log level. INFO if not set, otherwise DEBUG or your value here is used.")
+    parser.add_argument('-n', '--namespace', default='http://my.name.space/',
+                        help="Namespace for your objects in the output. `http://my.name.space/` by default.")
+    parser.add_argument('-o', '--out', default='ha.ttl',
+                        help="Set output filename; `ha.ttl` by default.")
+    parser.add_argument('-p', '--privacy', nargs='*', metavar='platform*',
+                        help="Enable privacy filter. `-p` gives a sensible default, otherwise use `-p person zone ...` to "
+                             "specify whitelist -- any other entities NOT in the filter will have their name replaced.")
+    # TODO: Add output filename
+    cli = CLISource(parser)
+    tool = HACVT(cli)
+    g = tool.main(debug=cli.args.debug, certificate=cli.args.certificate, privacy=cli.args.privacy, namespace=cli.args.namespace)
+    f_out = open(cli.args.out, "w")
+    print(g.serialize(format='turtle'), file=f_out)
+

--- a/tools/hass-to-rdt/hacvt_rdt.py
+++ b/tools/hass-to-rdt/hacvt_rdt.py
@@ -1,0 +1,682 @@
+"""
+hacvt_rdt.py — SOSA/RDT exporter for Home Assistant
+=====================================================
+Inherits from HACVT (hacvt.py) and overrides the ontology backend
+to produce .ttl files compatible with the RDT SmartNode ontology:
+  http://www.semanticweb.org/ivans/ontologies/2025/ruleless-digital-twins/
+
+Key differences from hacvt.py (SAREF backend):
+  - Uses SOSA (http://www.w3.org/ns/sosa/) and SSN namespaces
+  - Maps HA domains → sosa:Sensor / sosa:Actuator / sosa:Platform
+  - Attaches rdt:hasIdentifier with the raw HA entity_id
+  - Queries /api/services to capture possible actuator states
+    and emits rdt:hasActuatorState triples for each
+  - ObservableProperty used for sensor measurement targets
+  - No SAREF, S4BLDG or homeassistantcore.rdf side-effect
+
+Usage (same CLI as hacvt.py):
+  python hacvt_rdt.py http://homeassistant.local:8123/api/ HA_TOKEN \\
+      --namespace "http://www.semanticweb.org/rayan/ontologies/2025/ha/" \\
+      --out ha_rdt.ttl
+"""
+
+import argparse
+import logging
+from typing import Optional
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import Namespace, RDF, RDFS, OWL, XSD
+
+import homeassistant.const as hc
+import homeassistant.core as ha
+
+from ConfigSource import CLISource
+from hacvt import HACVT, PrivacyFilter, mkname
+from actuator_states import (
+    extract_fan_states,
+    extract_climate_states,
+    extract_cover_states,
+    extract_input_select_states,
+)
+
+
+# ---------------------------------------------------------------------------
+# Namespaces
+# ---------------------------------------------------------------------------
+SOSA_NS = Namespace("http://www.w3.org/ns/sosa/")
+SSN_NS  = Namespace("http://www.w3.org/ns/ssn/")
+RDT_NS  = Namespace(
+    "http://www.semanticweb.org/ivans/ontologies/2025/ruleless-digital-twins/"
+)
+
+
+# ---------------------------------------------------------------------------
+# Domain → SOSA class mapping
+# ---------------------------------------------------------------------------
+# True  → use HA sub-class  (HASS[domain.title()] rdfs:subClassOf sosa:X)
+# False → use sosa:X directly
+# None  → skip this domain entirely
+_DOMAIN_TO_SOSA: dict = {
+    hc.Platform.BINARY_SENSOR:       (False, "Sensor"),
+    hc.Platform.SENSOR:              (False, "Sensor"),
+    hc.Platform.AIR_QUALITY:         (True,  "Sensor"),
+    hc.Platform.DEVICE_TRACKER:      (True,  "Sensor"),
+    hc.Platform.WEATHER:             (True,  "Sensor"),
+    hc.Platform.SWITCH:              (True,  "Actuator"),
+    hc.Platform.FAN:                 (True,  "Actuator"),
+    hc.Platform.LIGHT:               (True,  "Actuator"),
+    hc.Platform.COVER:               (True,  "Actuator"),
+    hc.Platform.LOCK:                (True,  "Actuator"),
+    hc.Platform.HUMIDIFIER:          (True,  "Actuator"),
+    hc.Platform.SIREN:               (True,  "Actuator"),
+    hc.Platform.VACUUM:              (True,  "Actuator"),
+    hc.Platform.WATER_HEATER:        (True,  "Actuator"),
+    hc.Platform.CLIMATE:             (True,  "Actuator"),
+    hc.Platform.MEDIA_PLAYER:        (True,  "Actuator"),
+    hc.Platform.BUTTON:              (True,  "Actuator"),
+    hc.Platform.REMOTE:              (True,  "Actuator"),
+    # hc.Platform.VALVE was added in HA 2024+. Older HA versions (e.g. 2023.7.3
+    # pinned in the internship venv) raise AttributeError on direct access.
+    # Use getattr-on-class with a fallback sentinel string to stay forward-
+    # compatible without crashing. The sentinel will never collide with a real
+    # HA domain string.
+    (getattr(hc.Platform, "VALVE", "_internship_skip_valve_")): (True, "Actuator"),
+    hc.Platform.CAMERA:              (True,  "Platform"),
+    hc.Platform.ALARM_CONTROL_PANEL: (True,  "Platform"),
+    # HA helper domains (not in hc.Platform enum — string literals required)
+    "input_number":  (False, "Sensor"),   # virtual numeric sensors
+    "input_boolean": (False, "Sensor"),   # observable boolean states
+    "input_select":  (True,  "Actuator"), # mode selectors (set via select_option)
+    # Skipped domains
+    hc.Platform.CALENDAR:         None,
+    hc.Platform.GEO_LOCATION:     None,
+    hc.Platform.IMAGE_PROCESSING: None,
+    hc.Platform.NOTIFY:           None,
+    hc.Platform.NUMBER:           None,
+    hc.Platform.SCENE:            None,
+    hc.Platform.SELECT:           None,
+    hc.Platform.STT:              None,
+    hc.Platform.TEXT:             None,
+    hc.Platform.TTS:              None,
+    hc.Platform.UPDATE:           None,
+}
+
+_ACTUATOR_DOMAINS = {
+    p for p, v in _DOMAIN_TO_SOSA.items()
+    if v is not None and v[1] == "Actuator"
+}
+
+# ---------------------------------------------------------------------------
+# Bug #2 fix — per-domain toggle state overrides
+# ---------------------------------------------------------------------------
+# Maps domain string → tuple of default states to emit (replaces "on"/"off")
+# Empty tuple () means: no toggle states at all for this domain
+_TOGGLE_OVERRIDE: dict = {
+    "lock":    ("locked", "unlocked"),
+    "cover":   ("open",   "closed", "stop"),
+    "valve":        ("open",   "closed"),
+    "button":       (),  # button has no meaningful toggle states
+    "remote":       (),  # remote uses service calls, not toggle states
+    "input_select": (),  # options are entity-specific; harvested from /api/services
+}
+
+# Domains that get "on"/"off" by default (unless overridden above)
+_TOGGLE_DEFAULT = {
+    "switch", "light", "fan", "climate",
+    "siren", "vacuum", "humidifier", "media_player",
+    "water_heater",
+}
+
+# ---------------------------------------------------------------------------
+# Actuation semantics — what each actuator domain AFFECTS.
+# ---------------------------------------------------------------------------
+# The HA API tells us a light exists and toggles on/off, but never that a
+# light affects "illuminance". That mapping is domain knowledge. We encode a
+# reasonable default per domain so the exporter can auto-generate the
+# actuator -> PropertyChange -> Property links the MAPE-K planner needs,
+# instead of requiring a hand-written overlay. The generated overlay is still
+# an editable ontological instance file: users can refine it via --enrich.
+_DOMAIN_TO_AFFECTED_PROPERTY: dict = {
+    "light":         "illuminance",
+    "switch":        "switch_state",
+    "fan":           "air_flow",
+    "climate":       "temperature",
+    "cover":         "position",
+    "lock":          "lock_state",
+    "media_player":  "playback_state",
+    "humidifier":    "humidity",
+    "siren":         "siren_state",
+    "vacuum":        "vacuum_state",
+    "water_heater":  "water_temperature",
+    "button":        "button_state",
+    "remote":        "remote_state",
+    "input_boolean": "boolean_state",
+    "input_select":  "selected_mode",
+    "valve":         "valve_position",
+}
+# Number of discrete steps generated per continuous lever (ConfigurableParameter).
+_CONFIG_PARAM_STEPS = 3  # min / mid / max
+
+# When picking one lever per actuator, prefer meaningful fields (a light's
+# brightness) over incidental ones (transition duration, flash). Fields not
+# listed keep their natural order, after the prioritised ones.
+_LEVER_FIELD_PRIORITY = [
+    "brightness", "brightness_pct", "percentage", "percentage_step",
+    "temperature", "target_temp_high", "target_temp_low", "target_temperature",
+    "position", "tilt_position", "volume_level", "color_temp", "humidity",
+]
+
+
+class HACVT_RDT(HACVT):
+    """
+    SOSA/RDT variant of HACVT.
+
+    Overrides:
+      - main()                  : sets up SOSA graph instead of SAREF
+      - _handle_entity_rdt()    : maps to sosa:Sensor / sosa:Actuator
+      - _add_possible_states()  : harvests /api/services for actuator states
+    """
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+    def main(
+        self,
+        debug=logging.INFO,
+        certificate=None,
+        privacy=None,
+        namespace="http://my.name.space/ha/",
+        max_levers=0,
+    ):
+        # Max number of continuous levers (ConfigurableParameters) to include,
+        # at most one per actuator. 0 keeps the clean on/off tree; raising it
+        # adds dimmer-style control but grows the simulation tree fast
+        # (each lever multiplies the combinations by _CONFIG_PARAM_STEPS).
+        self._max_levers = max_levers
+        logging.basicConfig(level=debug, format="%(levelname)s: %(message)s")
+        self.cs.ws = self.cs._ws_connect(certificate=certificate)
+        self.cs.ws_counter = 1
+
+        pf = PrivacyFilter(self.cs)
+        pf.privacyFilter_init(privacy=privacy)
+
+        g = Graph(bind_namespaces="core")
+        MINE, HASS = self._setup_sosa(g, namespace)
+
+        # Collectors for auto-generated actuation semantics.
+        self._rdt_actuators = []     # list of (e_node, domain)
+        self._rdt_configparams = []  # list of (e_node, field, v_min, v_max)
+
+        the_devices = self.cs.getDevices()
+        for d in the_devices:
+            d_g          = pf.mkDevice(MINE, d)
+            manufacturer = self.cs.getDeviceAttr(d, hc.ATTR_MANUFACTURER)
+            name         = self.cs.getDeviceAttr(d, hc.ATTR_NAME)
+            model        = self.cs.getDeviceAttr(d, hc.ATTR_MODEL)
+
+            # ----------------------------------------------------------
+            # Bug #1 fix — avoid mine:device/None_None superclass
+            # Only create a named sub-class when both manufacturer AND
+            # model are real values; otherwise type directly as Platform.
+            # ----------------------------------------------------------
+            mfr_valid = manufacturer and str(manufacturer) not in ("None", "")
+            mdl_valid = model        and str(model)        not in ("None", "")
+            if mfr_valid and mdl_valid:
+                d_super = MINE["device/" + mkname(manufacturer) + "_" + mkname(model)]
+                g.add((d_super, RDFS.subClassOf, SOSA_NS["Platform"]))
+                g.add((d_g,     RDF.type,         d_super))
+            else:
+                g.add((d_g, RDF.type, SOSA_NS["Platform"]))
+
+            g.add((d_g, RDFS.label, Literal(name)))
+
+            # Area
+            d_area    = self.cs.getYAMLText(f'area_id("{d}")')
+            area_name = self.cs.getYAMLText(f'area_name("{d}")')
+            if d_area.strip() not in ("None", ""):
+                area = pf.mkLocationURI(MINE, d_area.strip())
+                g.add((area,  RDF.type,            SOSA_NS["Platform"]))
+                g.add((area,  RDFS.label,           Literal(area_name.strip())))
+                g.add((d_g,   SSN_NS["isHostedBy"], area))
+
+            # Entities hosted by this device
+            es = self.cs.getDeviceEntities(d)
+            for e in es:
+                if not (isinstance(e, str) and e.count(".") == 1):
+                    continue
+                e_node = self._handle_entity_rdt(pf, MINE, HASS, d, e, g)
+                if e_node is not None:
+                    g.add((d_g, SOSA_NS["hosts"], e_node))
+
+        # Entities without a parent device
+        for e_state in self._get_entities_wo_device():
+            e_id = e_state["entity_id"]
+            if e_id.count(".") != 1:
+                continue
+            self._handle_entity_rdt(pf, MINE, HASS, None, e_id, g)
+
+        # Auto-generate the actuation model (system platform, actuator ->
+        # PropertyChange -> Property links, and ConfigurableParameters).
+        self._emit_rdt_actuation(g, MINE)
+
+        logging.info("Serialising RDT/SOSA graph ...")
+        return g
+
+    # ------------------------------------------------------------------
+    # Auto-generated actuation semantics
+    # ------------------------------------------------------------------
+    def _emit_rdt_actuation(self, g: Graph, MINE: Namespace):
+        """Emit, from the collected actuators/config-params, everything the
+        MAPE-K planner needs to enumerate a simulation tree:
+          - a single system sosa:Platform carrying the enumeration flag and
+            hosting every actuator;
+          - per actuator: an ObservableProperty + a PropertyChangeByActuation
+            (ValueIncrease) + rdt:enacts;
+          - per continuous lever: a ConfigurableParameter with discrete
+            possible values + increase/decrease PropertyChanges.
+        All of this is instance-level semantics; the generic engine is
+        untouched."""
+        actuators = getattr(self, "_rdt_actuators", [])
+        configs   = getattr(self, "_rdt_configparams", [])
+        if not actuators and not configs:
+            return
+
+        # 1. System platform with the full-enumeration flag, hosting actuators.
+        system = MINE["ha_system"]
+        g.add((system, RDF.type, OWL.NamedIndividual))
+        g.add((system, RDF.type, SOSA_NS["Platform"]))
+        g.add((system, RDT_NS["generateCombinationsOnlyFromOptimalConditions"],
+               Literal(False)))
+
+        # 2. Per-actuator actuation link.
+        for e_node, domain in actuators:
+            g.add((system, SOSA_NS["hosts"], e_node))
+            prop_name = _DOMAIN_TO_AFFECTED_PROPERTY.get(domain, "state")
+            local     = mkname(str(e_node).rsplit("/", 1)[-1])
+            prop      = MINE[f"prop/{local}_{prop_name}"]
+            change    = MINE[f"change/{local}"]
+            g.add((prop, RDF.type, OWL.NamedIndividual))
+            g.add((prop, RDF.type, SOSA_NS["ObservableProperty"]))
+            g.add((prop, RDT_NS["hasValue"], Literal(0.0)))
+            g.add((change, RDF.type, OWL.NamedIndividual))
+            g.add((change, RDF.type, RDT_NS["PropertyChangeByActuation"]))
+            g.add((change, SSN_NS["forProperty"], prop))
+            g.add((change, RDT_NS["affectsPropertyWith"], RDT_NS["ValueIncrease"]))
+            g.add((e_node, RDT_NS["enacts"], change))
+            g.add((e_node, RDT_NS["hasActuatorName"], Literal(f"{local}_state")))
+
+        # 3. Per continuous lever: a ConfigurableParameter with N discrete
+        #    possible values and increase/decrease PropertyChanges.
+        #    Capped to at most one lever per actuator and `_max_levers` total,
+        #    to keep the simulation tree from exploding (each lever multiplies
+        #    the combination count by _CONFIG_PARAM_STEPS).
+        max_levers = getattr(self, "_max_levers", 0)
+        selected, seen_actuators = [], set()
+        if max_levers > 0:
+            # Prefer meaningful fields (brightness) over incidental ones
+            # (transition). Stable sort: prioritised fields first, rest as-is.
+            def _prio(entry):
+                field = entry[1]
+                return _LEVER_FIELD_PRIORITY.index(field) if field in _LEVER_FIELD_PRIORITY else len(_LEVER_FIELD_PRIORITY)
+            for entry in sorted(configs, key=_prio):
+                e_node = entry[0]
+                if e_node in seen_actuators:
+                    continue            # one lever per actuator
+                seen_actuators.add(e_node)
+                selected.append(entry)
+                if len(selected) >= max_levers:
+                    break
+        configs = selected
+
+        for e_node, field, v_min, v_max, entity_id, domain in configs:
+            g.add((system, SOSA_NS["hosts"], e_node))
+            local     = mkname(str(e_node).rsplit("/", 1)[-1])
+            fname     = mkname(field)
+            prop      = MINE[f"prop/{local}_{fname}"]
+            param     = MINE[f"param/{local}_{fname}"]
+            inc       = MINE[f"change/{local}_{fname}_inc"]
+            dec       = MINE[f"change/{local}_{fname}_dec"]
+            g.add((prop, RDF.type, OWL.NamedIndividual))
+            g.add((prop, RDF.type, SOSA_NS["ObservableProperty"]))
+            g.add((prop, RDT_NS["hasValue"], Literal(0.0)))
+            for ch, direction in ((inc, "ValueIncrease"), (dec, "ValueDecrease")):
+                g.add((ch, RDF.type, OWL.NamedIndividual))
+                g.add((ch, RDF.type, RDT_NS["PropertyChangeByActuation"]))
+                g.add((ch, SSN_NS["forProperty"], prop))
+                g.add((ch, RDT_NS["affectsPropertyWith"], RDT_NS[direction]))
+            g.add((param, RDF.type, OWL.NamedIndividual))
+            g.add((param, RDF.type, RDT_NS["ConfigurableParameter"]))
+            g.add((param, RDT_NS["enacts"], inc))
+            g.add((param, RDT_NS["enacts"], dec))
+            # Runtime binding: which HA entity + service field this lever drives,
+            # so HaConfigurableParameter can POST the chosen value back to HA.
+            g.add((param, RDT_NS["hasIdentifier"], Literal(entity_id, datatype=XSD.string)))
+            g.add((param, RDT_NS["hasActuatorName"], Literal(field, datatype=XSD.string)))
+            # N discrete possible values (min / mid / max for N=3).
+            levels = self._discrete_levels(v_min, v_max, _CONFIG_PARAM_STEPS)
+            for val in levels:
+                g.add((param, RDT_NS["hasPossibleValue"],
+                       Literal(val, datatype=XSD.double)))
+            # Current value — the MAPE-K Monitor reads `meta:hasValue` to seed
+            # the parameter in its cache. Without it the planner throws a
+            # KeyNotFoundException when building ReconfigurationActions. Seed it
+            # with the first (minimum) level.
+            if levels:
+                g.add((param, RDT_NS["hasValue"],
+                       Literal(levels[0], datatype=XSD.double)))
+
+        n_act = len(actuators)
+        n_cfg = len(configs)
+        logging.info(
+            f"Auto-generated actuation: 1 system platform, {n_act} actuator "
+            f"link(s), {n_cfg} configurable parameter(s).")
+
+    @staticmethod
+    def _discrete_levels(v_min, v_max, steps):
+        """Return `steps` evenly-spaced values from v_min to v_max inclusive."""
+        try:
+            lo = float(v_min)
+            hi = float(v_max)
+        except (TypeError, ValueError):
+            return []
+        if steps <= 1 or hi <= lo:
+            return [lo]
+        span = (hi - lo) / (steps - 1)
+        return [round(lo + span * i, 4) for i in range(steps)]
+
+    # ------------------------------------------------------------------
+    # Graph / namespace setup
+    # ------------------------------------------------------------------
+    def _setup_sosa(self, g: Graph, namespace: str):
+        MINE = Namespace(namespace)
+        HASS = Namespace("https://www.foldr.org/profiles/homeassistant/")
+
+        g.bind("sosa",  SOSA_NS)
+        g.bind("ssn",   SSN_NS)
+        g.bind("rdt",   RDT_NS)
+        g.bind("hass",  HASS)
+        g.bind("mine",  MINE)
+        g.bind("owl",   OWL)
+
+        ont = URIRef(str(MINE))
+        g.add((ont, RDF.type,    OWL.Ontology))
+        g.add((ont, OWL.imports, URIRef("http://www.w3.org/ns/ssn/")))
+        g.add((ont, OWL.imports, URIRef("http://www.w3.org/ns/sosa/")))
+
+        # Declare RDT datatype properties so the file is self-contained
+        for prop in ("hasIdentifier", "hasActuatorState", "hasPossibleValue"):
+            g.add((RDT_NS[prop], RDF.type, OWL.DatatypeProperty))
+
+        # Sub-class HA domains under the appropriate SOSA class
+        for domain, mapping in _DOMAIN_TO_SOSA.items():
+            if mapping is None:
+                continue
+            subclass_flag, sosa_class = mapping
+            if subclass_flag:
+                g.add((HASS[domain.title()], RDFS.subClassOf, SOSA_NS[sosa_class]))
+
+        return MINE, HASS
+
+    # ------------------------------------------------------------------
+    # Entity handler — SOSA version
+    # ------------------------------------------------------------------
+    def _handle_entity_rdt(
+        self,
+        pf: PrivacyFilter,
+        MINE: Namespace,
+        HASS: Namespace,
+        device: Optional[str],
+        entity_id: str,
+        g: Graph,
+    ) -> Optional[URIRef]:
+
+        domain, _ = ha.split_entity_id(entity_id)
+        mapping   = _DOMAIN_TO_SOSA.get(domain)
+
+        if mapping is None:
+            logging.warning(f"Skipping {entity_id}: domain '{domain}' not mapped.")
+            return None
+
+        subclass_flag, sosa_class = mapping
+        sosa_type = HASS[domain.title()] if subclass_flag else SOSA_NS[sosa_class]
+
+        e_node, e_name = pf.mkEntityURI(MINE, entity_id)
+        g.add((e_node, RDF.type,               sosa_type))
+        # Also assert the direct SOSA type (sosa:Sensor / sosa:Actuator /
+        # sosa:Platform). The RDT inference engine does not propagate
+        # rdfs:subClassOf, and the MAPE-K SPARQL queries match the direct
+        # type (e.g. `?actuator a sosa:Actuator`). Without this, actuators
+        # typed only via a domain subclass (a hass:Light) are invisible to
+        # the planner and the simulation tree comes out empty.
+        if subclass_flag:
+            g.add((e_node, RDF.type, SOSA_NS[sosa_class]))
+        g.add((e_node, RDT_NS["hasIdentifier"], Literal(entity_id, datatype=XSD.string)))
+
+        # Friendly name
+        try:
+            attrs = self.cs.getAttributes(entity_id)
+            fname = attrs.get(hc.ATTR_FRIENDLY_NAME)
+            if fname:
+                g.add((e_node, RDFS.label, Literal(fname)))
+        except Exception:
+            pass
+
+        # Sensors: link to an ObservableProperty + emit a Procedure
+        if sosa_class == "Sensor":
+            prop_node = MINE["property/" + mkname(e_name)]
+            g.add((prop_node, RDF.type,           SOSA_NS["ObservableProperty"]))
+            g.add((e_node,    SOSA_NS["observes"], prop_node))
+
+            proc_node = MINE["procedure/" + mkname(e_name)]
+            g.add((proc_node, RDF.type,            SOSA_NS["Procedure"]))
+            g.add((e_node,    SSN_NS["implements"], proc_node))
+            # Mirror the ObservableProperty on the Procedure (consistent with
+            # upstream instance-model-1.ttl which links Procedure → inputs).
+            g.add((proc_node, SOSA_NS["observes"], prop_node))
+
+        # Actuators: harvest possible states; only attach Procedure when useful
+        elif sosa_class == "Actuator":
+            # Record this actuator so _emit_rdt_actuation can wire its
+            # PropertyChange/system-platform links after all entities are seen.
+            if hasattr(self, "_rdt_actuators"):
+                self._rdt_actuators.append((e_node, domain))
+            states_added = self._add_possible_states(g, MINE, e_node, entity_id, domain)
+            # Bug #3 fix — only create sosa:Procedure when the actuator
+            # actually has states to expose (button/remote have none).
+            if states_added > 0:
+                proc_node = MINE["procedure/" + mkname(e_name)]
+                g.add((proc_node, RDF.type,             SOSA_NS["Procedure"]))
+                g.add((e_node,    SOSA_NS["implements"], proc_node))
+
+        return e_node
+
+    # ------------------------------------------------------------------
+    # Domain-specific state extractors — thin aliases to actuator_states.py
+    # (kept as static methods so existing call-sites stay unchanged).
+    # ------------------------------------------------------------------
+    _extract_fan_states          = staticmethod(extract_fan_states)
+    _extract_climate_states      = staticmethod(extract_climate_states)
+    _extract_cover_states        = staticmethod(extract_cover_states)
+    _extract_input_select_states = staticmethod(extract_input_select_states)
+
+    # ------------------------------------------------------------------
+    # Harvest possible actuator states from /api/services and entity attrs.
+    # Returns the number of rdt:hasActuatorState triples added.
+    # ------------------------------------------------------------------
+    def _add_possible_states(
+        self,
+        g: Graph,
+        MINE: Namespace,
+        e_node: URIRef,
+        entity_id: str,
+        domain,
+    ) -> int:
+        """
+        Populate rdt:hasActuatorState triples.
+
+        Strategy:
+          1. Emit domain-specific toggle states (via _TOGGLE_OVERRIDE /
+             _TOGGLE_DEFAULT) — Bug #2 fix: lock → locked/unlocked,
+             cover → open/closed/stop, button/remote → nothing.
+          2. Run domain-specific attribute extractor if one exists
+             (fan, climate, cover, input_select).
+          3. Inspect /api/services service fields:
+             - selector.select  → explicit enum values
+             - selector.number  → range annotation string range:min:max:stepN
+             - selector.boolean → "true" / "false"
+
+        Returns the total count of triples added.
+        """
+        count      = 0
+        services   = self.cs.getServices()
+        domain_key = str(domain)
+
+        # --- Bug #2 fix: per-domain toggle states ---
+        if domain_key in _TOGGLE_OVERRIDE:
+            toggle_states = _TOGGLE_OVERRIDE[domain_key]
+        elif domain_key in _TOGGLE_DEFAULT:
+            toggle_states = ("on", "off")
+        else:
+            toggle_states = ()
+
+        for state in toggle_states:
+            g.add((e_node, RDT_NS["hasActuatorState"], Literal(state)))
+            count += 1
+
+        # --- Domain-specific attribute extractors ---
+        _attr_extractors = {
+            "fan":          self._extract_fan_states,
+            "climate":      self._extract_climate_states,
+            "cover":        self._extract_cover_states,
+            "input_select": self._extract_input_select_states,
+        }
+        if domain_key in _attr_extractors:
+            try:
+                attrs = self.cs.getAttributes(entity_id) or {}
+            except Exception:
+                attrs = {}
+            svc_info = services.get(domain_key, {})
+            extracted = _attr_extractors[domain_key](attrs, svc_info)
+            # Deduplicate against already-emitted toggle states
+            seen = set(toggle_states)
+            for state in extracted:
+                if state not in seen:
+                    g.add((e_node, RDT_NS["hasActuatorState"], Literal(state)))
+                    count += 1
+                    seen.add(state)
+
+        # --- /api/services selector fields ---
+        if domain_key not in services:
+            return count
+
+        svc_map = services[domain_key]
+        for svc_name, svc_info in svc_map.items():
+            if not isinstance(svc_info, dict):
+                continue
+            fields = svc_info.get("fields", {})
+            for field_name, field_info in fields.items():
+                if not isinstance(field_info, dict):
+                    continue
+                selector = field_info.get("selector", {})
+                if not isinstance(selector, dict):
+                    continue
+
+                # Explicit enum of possible values
+                if "select" in selector:
+                    options = selector["select"].get("options", [])
+                    for opt in options:
+                        val = opt if isinstance(opt, str) else opt.get("value", "")
+                        if val:
+                            g.add((e_node, RDT_NS["hasActuatorState"], Literal(val)))
+                            count += 1
+
+                # Numeric range (e.g. a light's brightness/color_temp number
+                # field). A continuous range is NOT a discrete actuation state:
+                # in the RDT model it is a ConfigurableParameter, not an
+                # ActuatorState. We do NOT emit it as rdt:hasActuatorState
+                # (that exploded the cartesian product); instead we record it
+                # so _emit_rdt_actuation can model it as a ConfigurableParameter
+                # with a small number of discrete possible values.
+                if "number" in selector:
+                    num_sel = selector["number"]
+                    v_min   = num_sel.get("min")
+                    v_max   = num_sel.get("max")
+                    if v_min is not None and v_max is not None and hasattr(self, "_rdt_configparams"):
+                        self._rdt_configparams.append(
+                            (e_node, field_name, v_min, v_max, entity_id, domain))
+
+                # Boolean field
+                if "boolean" in selector:
+                    for bv in ("true", "false"):
+                        g.add((e_node, RDT_NS["hasActuatorState"], Literal(bv)))
+                        count += 2
+
+        return count
+
+    # ------------------------------------------------------------------
+    # Bug #4 fix — normalize getDeviceId() return value
+    # getDeviceId() may return Python None OR the string "None"
+    # ------------------------------------------------------------------
+    def _get_entities_wo_device(self):
+        for k in self.cs.getStates():
+            raw = self.cs.getDeviceId(k["entity_id"])
+            if not raw or str(raw).strip() in ("None", ""):
+                yield k
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Export a Home Assistant instance to a SOSA/RDT-compatible .ttl file."
+    )
+    parser.add_argument(
+        "-d", "--debug", default="INFO", const="DEBUG", nargs="?",
+        help="Log level (INFO by default, DEBUG if flag given alone).",
+    )
+    parser.add_argument(
+        "-n", "--namespace",
+        default="http://www.semanticweb.org/rayan/ontologies/2025/ha/",
+        help="Base namespace for generated individuals.",
+    )
+    parser.add_argument(
+        "-o", "--out", default="ha_rdt.ttl",
+        help="Output .ttl file (default: ha_rdt.ttl).",
+    )
+    parser.add_argument(
+        "-p", "--privacy", nargs="*", metavar="platform",
+        help="Enable privacy filter.",
+    )
+    parser.add_argument(
+        "-e", "--enrich", action="append", default=None, metavar="overlay.ttl",
+        help="Merge an extra instance-level overlay into the export (repeatable). "
+             "The actuator->PropertyChange links and the system platform are now "
+             "auto-generated, so this is only for additional hand-authored "
+             "semantics.",
+    )
+    parser.add_argument(
+        "-l", "--levers", type=int, default=0, metavar="N",
+        help="Include up to N continuous levers (ConfigurableParameters, e.g. a "
+             "light's brightness) with %d discrete steps each, at most one per "
+             "actuator. Default 0 keeps the clean on/off tree; each lever "
+             "multiplies the simulation-tree size." % _CONFIG_PARAM_STEPS,
+    )
+
+    cli  = CLISource(parser)
+    tool = HACVT_RDT(cli)
+    g    = tool.main(
+        debug=cli.args.debug,
+        certificate=cli.args.certificate,
+        privacy=cli.args.privacy,
+        namespace=cli.args.namespace,
+        max_levers=cli.args.levers,
+    )
+    # Merge any instance-level overlays. Same namespaces -> triples fold in.
+    for overlay in (cli.args.enrich or []):
+        before = len(g)
+        g.parse(overlay, format="turtle")
+        logging.info(f"Merged overlay '{overlay}' (+{len(g) - before} triples).")
+    with open(cli.args.out, "w") as f_out:
+        f_out.write(g.serialize(format="turtle"))
+    print(f"Written to {cli.args.out}")

--- a/tools/hass-to-rdt/requirements-cli.txt
+++ b/tools/hass-to-rdt/requirements-cli.txt
@@ -1,0 +1,20 @@
+# Minimal Python deps for the CLI export path (hacvt_rdt.py).
+# Compared to the upstream HASS-to-OWL-exporter requirements.txt, this
+# excludes Flask / Celery / Redis / SAREF tooling — kept only what the
+# RDT exporter actually imports through hacvt.py and ConfigSource.py.
+#
+# Most transitive deps (voluptuous, aiohttp, awesomeversion, …) come in
+# automatically via the `homeassistant` package.
+
+forcediphttpsadapter
+homeassistant
+PyYAML
+rdflib
+requests
+requests-cache
+websocket-client
+
+# Dev-only dependency for the WP1 generator tests (gen_bindings.py).
+# Not required to run hacvt_rdt.py against a live HA, but needed to run
+# `python -m pytest tools/hass-to-rdt/tests`.
+pytest

--- a/tools/hass-to-rdt/tests/conftest.py
+++ b/tools/hass-to-rdt/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for tools/hass-to-rdt tests."""
+
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make ``binding`` and ``gen_bindings`` importable without an editable install.
+_TOOL_ROOT = Path(__file__).resolve().parent.parent
+if str(_TOOL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TOOL_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def block_network(monkeypatch):
+    """Refuse any TCP socket.connect call inside the test process."""
+    def _refuse(*_args, **_kwargs):
+        raise RuntimeError("network access is not allowed in tests")
+    monkeypatch.setattr(socket.socket, "connect", _refuse)

--- a/tools/hass-to-rdt/tests/test_actuator_states.py
+++ b/tools/hass-to-rdt/tests/test_actuator_states.py
@@ -1,0 +1,288 @@
+"""
+Tests for the domain-specific actuator-state extractors.
+
+All tests are fully offline: no live HA, no network (enforced by the
+block_network fixture in conftest.py), no ``homeassistant`` package required.
+
+The pure functions live in actuator_states.py.  The integration path through
+HACVT_RDT._add_possible_states is tested via a minimal stub that replaces
+the homeassistant-dependent machinery with fakes.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from rdflib import Graph, Literal
+from rdflib.namespace import Namespace, URIRef
+
+# Make the tool root importable (same trick as conftest.py).
+_TOOL_ROOT = Path(__file__).resolve().parent.parent
+if str(_TOOL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TOOL_ROOT))
+
+import actuator_states as as_mod
+
+# RDT namespace literal (avoids importing hacvt_rdt and pulling in homeassistant).
+_RDT = "http://www.semanticweb.org/ivans/ontologies/2025/ruleless-digital-twins/"
+_RDT_HAS_ACTUATOR_STATE = URIRef(_RDT + "hasActuatorState")
+
+# Toggle-state overrides mirrored from hacvt_rdt (used in integration stubs).
+_TOGGLE_OVERRIDE = {
+    "lock":         ("locked", "unlocked"),
+    "cover":        ("open",   "closed", "stop"),
+    "valve":        ("open",   "closed"),
+    "button":       (),
+    "remote":       (),
+    "input_select": (),
+}
+_TOGGLE_DEFAULT = {
+    "switch", "light", "fan", "climate",
+    "siren", "vacuum", "humidifier", "media_player", "water_heater",
+}
+
+
+# ---------------------------------------------------------------------------
+# Integration helper — mimics _add_possible_states without homeassistant
+# ---------------------------------------------------------------------------
+
+def _add_states(attrs: dict, domain: str, services: dict | None = None) -> set[str]:
+    """
+    Runs the same logic as HACVT_RDT._add_possible_states but without
+    importing homeassistant.  Returns the set of emitted state strings.
+    """
+    from rdflib import Literal
+    from rdflib.namespace import Namespace
+
+    services = services or {}
+    g = Graph()
+    MINE = Namespace("http://test/")
+    e_node = MINE["entity/test"]
+
+    domain_key = str(domain)
+
+    # Toggle states
+    if domain_key in _TOGGLE_OVERRIDE:
+        toggle_states = _TOGGLE_OVERRIDE[domain_key]
+    elif domain_key in _TOGGLE_DEFAULT:
+        toggle_states = ("on", "off")
+    else:
+        toggle_states = ()
+
+    for s in toggle_states:
+        g.add((e_node, _RDT_HAS_ACTUATOR_STATE, Literal(s)))
+
+    # Attribute extractors
+    _extractors = {
+        "fan":          as_mod.extract_fan_states,
+        "climate":      as_mod.extract_climate_states,
+        "cover":        as_mod.extract_cover_states,
+        "input_select": as_mod.extract_input_select_states,
+    }
+    if domain_key in _extractors:
+        svc_info = services.get(domain_key, {})
+        extracted = _extractors[domain_key](attrs, svc_info)
+        seen = set(toggle_states)
+        for s in extracted:
+            if s not in seen:
+                g.add((e_node, _RDT_HAS_ACTUATOR_STATE, Literal(s)))
+                seen.add(s)
+
+    return {str(obj) for _, _, obj in g.triples((e_node, _RDT_HAS_ACTUATOR_STATE, None))}
+
+
+# ===========================================================================
+# extract_fan_states
+# ===========================================================================
+
+class TestExtractFanStates:
+
+    def test_preset_modes_returned(self):
+        attrs = {"preset_modes": ["auto", "sleep", "turbo"]}
+        assert as_mod.extract_fan_states(attrs, {}) == ["auto", "sleep", "turbo"]
+
+    def test_speed_list_returned_when_no_presets(self):
+        attrs = {"speed_list": ["low", "medium", "high"]}
+        assert as_mod.extract_fan_states(attrs, {}) == ["low", "medium", "high"]
+
+    def test_both_present_warns_and_returns_both(self, capsys):
+        attrs = {
+            "preset_modes": ["auto", "sleep"],
+            "speed_list":   ["low", "high"],
+        }
+        result = as_mod.extract_fan_states(attrs, {})
+        assert "auto" in result
+        assert "sleep" in result
+        assert "low" in result
+        assert "high" in result
+        stderr = capsys.readouterr().err
+        assert "WARNING" in stderr
+        assert "preset_modes" in stderr
+        assert "speed_list" in stderr
+
+    def test_speed_list_deduped_against_presets(self):
+        # "auto" appears in both lists — must not duplicate
+        attrs = {"preset_modes": ["auto"], "speed_list": ["auto", "turbo"]}
+        result = as_mod.extract_fan_states(attrs, {})
+        assert result.count("auto") == 1
+        assert "turbo" in result
+
+    def test_percentage_step_generates_range(self):
+        attrs = {"percentage_step": 25}
+        result = as_mod.extract_fan_states(attrs, {})
+        assert "pct:0"   in result
+        assert "pct:25"  in result
+        assert "pct:50"  in result
+        assert "pct:75"  in result
+        assert "pct:100" in result
+
+    def test_empty_attrs_returns_empty(self):
+        assert as_mod.extract_fan_states({}, {}) == []
+
+    def test_invalid_percentage_step_does_not_crash(self):
+        attrs = {"percentage_step": "not-a-number"}
+        assert as_mod.extract_fan_states(attrs, {}) == []
+
+    def test_fan_integrated_toggle_plus_presets(self):
+        states = _add_states({"preset_modes": ["eco", "boost"]}, "fan")
+        assert "eco" in states
+        assert "boost" in states
+        assert "on" in states
+        assert "off" in states
+
+
+# ===========================================================================
+# extract_climate_states
+# ===========================================================================
+
+class TestExtractClimateStates:
+
+    def test_hvac_modes_returned_without_prefix(self):
+        attrs = {"hvac_modes": ["off", "heat", "cool", "auto"]}
+        result = as_mod.extract_climate_states(attrs, {})
+        assert "off" in result
+        assert "heat" in result
+
+    def test_preset_modes_prefixed(self):
+        attrs = {"preset_modes": ["away", "home", "sleep"]}
+        result = as_mod.extract_climate_states(attrs, {})
+        assert "preset:away"  in result
+        assert "preset:home"  in result
+        assert "preset:sleep" in result
+        assert "away" not in result  # must carry prefix
+
+    def test_fan_modes_prefixed(self):
+        attrs = {"fan_modes": ["low", "medium", "high", "auto"]}
+        result = as_mod.extract_climate_states(attrs, {})
+        assert "fan:low"  in result
+        assert "fan:auto" in result
+
+    def test_swing_modes_prefixed(self):
+        attrs = {"swing_modes": ["off", "vertical"]}
+        result = as_mod.extract_climate_states(attrs, {})
+        assert "swing:off"      in result
+        assert "swing:vertical" in result
+
+    def test_all_sub_lists_combined(self):
+        attrs = {
+            "hvac_modes":   ["off", "heat"],
+            "preset_modes": ["away"],
+            "fan_modes":    ["low"],
+            "swing_modes":  ["off"],
+        }
+        result = as_mod.extract_climate_states(attrs, {})
+        assert "heat"         in result
+        assert "preset:away"  in result
+        assert "fan:low"      in result
+        assert "swing:off"    in result
+
+    def test_empty_attrs_returns_empty(self):
+        assert as_mod.extract_climate_states({}, {}) == []
+
+    def test_none_sub_lists_do_not_crash(self):
+        attrs = {"hvac_modes": None, "preset_modes": None}
+        assert as_mod.extract_climate_states(attrs, {}) == []
+
+    def test_climate_integrated(self):
+        states = _add_states(
+            {"hvac_modes": ["off", "cool"], "preset_modes": ["home"]},
+            "climate",
+        )
+        assert "off"          in states
+        assert "cool"         in states
+        assert "preset:home"  in states
+
+
+# ===========================================================================
+# extract_cover_states
+# ===========================================================================
+
+class TestExtractCoverStates:
+
+    def test_without_tilt_returns_open_closed(self):
+        assert set(as_mod.extract_cover_states({}, {})) == {"open", "closed"}
+
+    def test_with_tilt_attribute_returns_three_states(self):
+        attrs = {"current_tilt_position": 50}
+        assert set(as_mod.extract_cover_states(attrs, {})) == {"open", "half-open", "closed"}
+
+    def test_tilt_position_zero_still_triggers(self):
+        # Value 0 is falsy; key presence is what matters
+        attrs = {"current_tilt_position": 0}
+        assert "half-open" in as_mod.extract_cover_states(attrs, {})
+
+    def test_cover_integrated_no_tilt(self):
+        states = _add_states({}, "cover")
+        assert "open"   in states
+        assert "closed" in states
+        assert "stop"   in states
+
+    def test_cover_integrated_with_tilt(self):
+        states = _add_states({"current_tilt_position": 50}, "cover")
+        assert "half-open" in states
+        assert "open"      in states
+        assert "closed"    in states
+
+    def test_open_closed_not_duplicated_by_extractor(self):
+        # _TOGGLE_OVERRIDE["cover"] already has open/closed/stop;
+        # _extract_cover_states also returns open/closed.
+        # Integration layer must not emit duplicates.
+        states_list = list(_add_states({}, "cover"))
+        assert states_list.count("open")   == 1
+        assert states_list.count("closed") == 1
+
+
+# ===========================================================================
+# extract_input_select_states
+# ===========================================================================
+
+class TestExtractInputSelectStates:
+
+    def test_options_returned_as_is(self):
+        attrs = {"options": ["mode1", "mode2", "mode3"]}
+        assert as_mod.extract_input_select_states(attrs, {}) == ["mode1", "mode2", "mode3"]
+
+    def test_numeric_options_coerced_to_str(self):
+        attrs = {"options": [1, 2, 3]}
+        assert as_mod.extract_input_select_states(attrs, {}) == ["1", "2", "3"]
+
+    def test_empty_options_returns_empty(self):
+        assert as_mod.extract_input_select_states({"options": []}, {}) == []
+
+    def test_missing_options_returns_empty(self):
+        assert as_mod.extract_input_select_states({}, {}) == []
+
+    def test_none_options_returns_empty(self):
+        assert as_mod.extract_input_select_states({"options": None}, {}) == []
+
+    def test_input_select_integrated(self):
+        states = _add_states({"options": ["eco", "comfort", "boost"]}, "input_select")
+        assert "eco"     in states
+        assert "comfort" in states
+        assert "boost"   in states
+
+    def test_missing_attrs_does_not_crash(self):
+        # Simulate getAttributes returning an empty dict (degraded gracefully)
+        states = _add_states({}, "input_select")
+        assert isinstance(states, set)

--- a/tools/hass-to-rdt/tests/test_config_params.py
+++ b/tools/hass-to-rdt/tests/test_config_params.py
@@ -1,0 +1,45 @@
+"""Tests for the ConfigurableParameter (continuous lever) support in
+hacvt_rdt.py: the discrete-level helper and the field-priority constant."""
+import pytest
+
+from hacvt_rdt import HACVT_RDT, _LEVER_FIELD_PRIORITY, _CONFIG_PARAM_STEPS
+
+
+class TestDiscreteLevels:
+    def test_three_steps_0_300(self):
+        assert HACVT_RDT._discrete_levels(0, 300, 3) == [0.0, 150.0, 300.0]
+
+    def test_three_steps_0_100(self):
+        assert HACVT_RDT._discrete_levels(0, 100, 3) == [0.0, 50.0, 100.0]
+
+    def test_five_steps(self):
+        assert HACVT_RDT._discrete_levels(0, 100, 5) == [0.0, 25.0, 50.0, 75.0, 100.0]
+
+    def test_two_steps_are_extremes(self):
+        assert HACVT_RDT._discrete_levels(0, 300, 2) == [0.0, 300.0]
+
+    def test_degenerate_min_equals_max(self):
+        # No span -> single value, never crashes.
+        assert HACVT_RDT._discrete_levels(5, 5, 3) == [5.0]
+
+    def test_one_step(self):
+        assert HACVT_RDT._discrete_levels(0, 300, 1) == [0.0]
+
+    def test_non_numeric_bounds_do_not_crash(self):
+        assert HACVT_RDT._discrete_levels("x", None, 3) == []
+
+    def test_default_step_count_is_three(self):
+        assert _CONFIG_PARAM_STEPS == 3
+
+
+class TestLeverFieldPriority:
+    def test_brightness_preferred_over_transition(self):
+        # brightness must be ranked (present) and transition must not be,
+        # so the "one lever per actuator" picker chooses brightness.
+        assert "brightness" in _LEVER_FIELD_PRIORITY
+        assert "brightness_pct" in _LEVER_FIELD_PRIORITY
+        assert "transition" not in _LEVER_FIELD_PRIORITY
+
+    def test_priority_is_ordered(self):
+        # brightness ranks before color_temp (more meaningful as a lever).
+        assert _LEVER_FIELD_PRIORITY.index("brightness") < _LEVER_FIELD_PRIORITY.index("color_temp")


### PR DESCRIPTION
## What

A standalone CLI (`tools/hass-to-rdt/`) that connects to a Home Assistant
instance over the REST API and exports its entities as a **SOSA/SSN + `rdt:`**
Turtle model:

- `a sosa:Sensor` / `a sosa:Actuator`
- `rdt:hasIdentifier` carrying the HA `entity_id`
- `rdt:hasActuatorState` discovered from `/api/services` and entity attributes
  (`fan`, `climate`, `cover`, `input_select`, …)
- `sosa:observes` / `ssn:implements` for sensors

## Why

Generate the RDT model from a Home Assistant instance instead of hand-modelling
it. Ports the SAREF-based `HASS-to-OWL-exporter` to the SOSA-based RDT
metamodel.

## Notes

- Standalone tool — no change to the SmartNode core.
- Offline tests included (`pytest`, no live HA and no token needed).
- Verified against `kristofferwagen/ha-instance` (59 sensors, 4 actuators).

Addresses #61
