### PR TITLE
Add TTL-driven Home Assistant runtime (factory, actuator, action translator)

### DIFF
--- a/SmartNode/Implementations/Actuators/HomeAssistant/HaActionTranslator.cs
+++ b/SmartNode/Implementations/Actuators/HomeAssistant/HaActionTranslator.cs
@@ -1,0 +1,63 @@
+namespace Implementations.Actuators.HomeAssistant {
+
+    /// <summary>
+    /// Translates an RDT actuator state (as emitted by the hass-to-rdt exporter)
+    /// into a concrete Home Assistant service call plus its JSON payload.
+    ///
+    /// Without this, a state like "on" would call /api/services/light/on, which
+    /// Home Assistant rejects — it expects /api/services/light/turn_on. Likewise
+    /// structured states ("pct:50", "preset:away", "fan:low", "swing:vertical")
+    /// must become a service with the matching data field, not part of the path.
+    /// </summary>
+    public static class HaActionTranslator {
+
+        public readonly record struct HaCall(string Service, IReadOnlyDictionary<string, object> Data);
+
+        /// <param name="domain">HA domain derived from the entity id (e.g. "light").</param>
+        /// <param name="entityId">Full HA entity id (e.g. "light.kitchen").</param>
+        /// <param name="state">RDT actuator state to apply.</param>
+        public static HaCall Translate(string domain, string entityId, string state) {
+            var data = new Dictionary<string, object> { ["entity_id"] = entityId };
+            string s = state ?? string.Empty;
+
+            // Structured states: "<field>:<value>"
+            if (s.StartsWith("pct:") && int.TryParse(s[4..], out int pct)) {
+                data["percentage"] = pct;
+                return new HaCall("set_percentage", data);
+            }
+            if (s.StartsWith("preset:")) {
+                data["preset_mode"] = s["preset:".Length..];
+                return new HaCall("set_preset_mode", data);
+            }
+            if (s.StartsWith("fan:")) {
+                data["fan_mode"] = s["fan:".Length..];
+                return new HaCall("set_fan_mode", data);
+            }
+            if (s.StartsWith("swing:")) {
+                data["swing_mode"] = s["swing:".Length..];
+                return new HaCall("set_swing_mode", data);
+            }
+
+            // Toggle states shared across domains.
+            switch (s) {
+                case "on":       return new HaCall("turn_on", data);
+                case "off":      return new HaCall("turn_off", data);
+                case "locked":   return new HaCall("lock", data);
+                case "unlocked": return new HaCall("unlock", data);
+            }
+
+            // Bare states that are domain-specific.
+            switch (domain) {
+                case "input_select":
+                    data["option"] = s;
+                    return new HaCall("select_option", data);
+                case "climate":
+                    data["hvac_mode"] = s;
+                    return new HaCall("set_hvac_mode", data);
+            }
+
+            // Fallback: treat the state as the service name itself.
+            return new HaCall(s, data);
+        }
+    }
+}

--- a/SmartNode/Implementations/Actuators/HomeAssistant/HaActuator.cs
+++ b/SmartNode/Implementations/Actuators/HomeAssistant/HaActuator.cs
@@ -1,0 +1,48 @@
+using Logic.TTComponentInterfaces;
+using System.Net.Http.Json;
+
+namespace Implementations.Actuators.HomeAssistant {
+
+    /// <summary>
+    /// Sends service calls to Home Assistant to actuate a device.
+    /// The HA entity domain is derived from the entity id (e.g. "switch.lab" → "switch").
+    /// RDT states are mapped to real HA services by <see cref="HaActionTranslator"/>.
+    /// </summary>
+    public class HaActuator : IActuator {
+        private readonly HttpClient _httpClient;
+        private readonly IReadOnlyList<string> _possibleStates;
+        private object _currentState;
+
+        public HaActuator(string actuatorName, string haEntityId, IReadOnlyList<string> possibleStates, HttpClient httpClient) {
+            ActuatorName    = actuatorName;
+            HaEntityId      = haEntityId;
+            _possibleStates = possibleStates;
+            _httpClient     = httpClient;
+            _currentState   = possibleStates.Count > 0 ? possibleStates[0] : "unknown";
+        }
+
+        public string ActuatorName { get; }
+
+        public string HaEntityId { get; }
+
+        public object ActuatorState => _currentState;
+
+        public async Task Actuate(object state) {
+            string stateStr = state?.ToString() ?? string.Empty;
+
+            // Derive domain from entity id, e.g. "switch.lab_light" → "switch".
+            int dotIndex = HaEntityId.IndexOf('.');
+            string domain = dotIndex >= 0 ? HaEntityId[..dotIndex] : HaEntityId;
+
+            // Map the RDT state to a real HA service + payload.
+            var call = HaActionTranslator.Translate(domain, HaEntityId, stateStr);
+            var requestUri = $"api/services/{domain}/{call.Service}";
+
+            var response = await _httpClient.PostAsJsonAsync(requestUri, call.Data);
+            response.EnsureSuccessStatusCode();
+
+            // Only record the new state once Home Assistant accepted the call.
+            _currentState = stateStr;
+        }
+    }
+}

--- a/SmartNode/Implementations/Actuators/HomeAssistant/HomeAssistantConnection.cs
+++ b/SmartNode/Implementations/Actuators/HomeAssistant/HomeAssistantConnection.cs
@@ -1,0 +1,36 @@
+namespace Implementations.Actuators.HomeAssistant {
+
+    /// <summary>
+    /// Builds the <see cref="HttpClient"/> used to talk to a Home Assistant
+    /// instance. Kept in Implementations so that the generic core never holds
+    /// Home Assistant transport details (base URL, bearer token).
+    ///
+    /// Environment variables:
+    ///   HA_BASE_URL (or HA_URL)  — host root, e.g. "http://homeassistant.local:8123/"
+    ///   HA_TOKEN    (or TOKEN_HA) — long-lived access token
+    /// </summary>
+    public static class HomeAssistantConnection {
+
+        public static HttpClient CreateFromEnvironment() {
+            string baseUrl = Environment.GetEnvironmentVariable("HA_BASE_URL")
+                ?? Environment.GetEnvironmentVariable("HA_URL")
+                ?? throw new InvalidOperationException(
+                    "HA_BASE_URL (or HA_URL) environment variable is required to reach Home Assistant.");
+            string token = Environment.GetEnvironmentVariable("HA_TOKEN")
+                ?? Environment.GetEnvironmentVariable("TOKEN_HA")
+                ?? throw new InvalidOperationException(
+                    "HA_TOKEN (or TOKEN_HA) environment variable is required to reach Home Assistant.");
+
+            if (!baseUrl.EndsWith('/')) baseUrl += "/";
+
+            var http = new HttpClient(new SocketsHttpHandler {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(2)
+            }) {
+                BaseAddress = new Uri(baseUrl)
+            };
+            http.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+            http.DefaultRequestHeaders.Add("User-Agent", "SmartNode-HA/1.0");
+            return http;
+        }
+    }
+}

--- a/SmartNode/SmartNode/Factories/HomeAssistantFactory.cs
+++ b/SmartNode/SmartNode/Factories/HomeAssistantFactory.cs
@@ -1,0 +1,102 @@
+using Implementations.Actuators.HomeAssistant;
+using Implementations.Sensors.HomeAssistant;
+using Logic.FactoryInterface;
+using Logic.TTComponentInterfaces;
+using SmartNode.Services.Bindings;
+
+namespace SmartNode.Factories {
+
+    /// <summary>
+    /// Factory populated entirely from a TTL SOSA/RDT bindings file, selected when
+    /// CoordinatorSettings.Environment == "homeassistant".
+    ///
+    /// Environment variables:
+    ///   HA_BINDINGS_TTL          — path to the SOSA/RDT instance produced by hass-to-rdt
+    ///   HA_BASE_URL / HA_TOKEN   — Home Assistant connection (see HomeAssistantConnection)
+    ///
+    /// Home Assistant transport (HttpClient, bearer token) lives in Implementations
+    /// via <see cref="HomeAssistantConnection"/>, so the generic core stays HA-agnostic.
+    /// </summary>
+    public class HomeAssistantFactory : AbstractFactory, IFactory {
+
+        public HomeAssistantFactory(IServiceProvider serviceProvider)
+            : base(BuildContext(serviceProvider)) { }
+
+        // Internal ctor used by tests to inject explicit bindings + HttpClient.
+        internal HomeAssistantFactory(BindingsResult bindings, HttpClient httpClient, IServiceProvider serviceProvider)
+            : base(new BindingsServiceProvider(bindings, httpClient, serviceProvider)) { }
+
+        private static IServiceProvider BuildContext(IServiceProvider inner) {
+            string ttlPath = Environment.GetEnvironmentVariable("HA_BINDINGS_TTL")
+                ?? throw new InvalidOperationException(
+                    "HA_BINDINGS_TTL environment variable is required for the homeassistant environment.");
+            BindingsResult bindings = TtlBindingsLoader.Load(ttlPath)
+                ?? throw new InvalidOperationException(
+                    $"Could not load TTL bindings from '{ttlPath}'.");
+            HttpClient http = HomeAssistantConnection.CreateFromEnvironment();
+            return new BindingsServiceProvider(bindings, http, inner);
+        }
+
+        protected override IDictionary<(string, string), ISensor> MakeSensorMap(IServiceProvider serviceProvider) {
+            var ctx      = (BindingsServiceProvider)serviceProvider;
+            var bindings = ctx.Bindings;
+            var http     = ctx.HttpClient;
+
+            var map = new Dictionary<(string, string), ISensor>();
+            foreach (var (_, sb) in bindings.SensorMap) {
+                if (string.IsNullOrEmpty(sb.HaEntityId)) {
+                    Console.WriteLine($"[HomeAssistantFactory] Skipping sensor '{sb.Uri}' — no HA entity id (rdt:hasIdentifier).");
+                    continue;
+                }
+                string procedureKey = string.IsNullOrEmpty(sb.ProcedureUri) ? sb.Uri : sb.ProcedureUri;
+                map[(sb.Uri, procedureKey)] =
+                    new HomeAssistantSensor(sb.Uri, sb.HaEntityId, attribute: null, http);
+            }
+            Console.WriteLine($"[HomeAssistantFactory] Built {map.Count} sensor(s) from TTL bindings.");
+            return map;
+        }
+
+        protected override IDictionary<string, IActuator> MakeActuatorMap(IServiceProvider serviceProvider) {
+            var ctx      = (BindingsServiceProvider)serviceProvider;
+            var bindings = ctx.Bindings;
+            var http     = ctx.HttpClient;
+
+            var map = new Dictionary<string, IActuator>();
+            foreach (var (_, ab) in bindings.ActuatorMap) {
+                if (string.IsNullOrEmpty(ab.HaEntityId)) {
+                    Console.WriteLine($"[HomeAssistantFactory] Skipping actuator '{ab.Uri}' — no HA entity id (rdt:hasIdentifier).");
+                    continue;
+                }
+                map[ab.Uri] = new HaActuator(ab.Uri, ab.HaEntityId, ab.PossibleStates, http);
+            }
+            Console.WriteLine($"[HomeAssistantFactory] Built {map.Count} actuator(s) from TTL bindings.");
+            return map;
+        }
+
+        protected override IDictionary<string, IConfigurableParameter> MakeConfigurableParameterMap(IServiceProvider serviceProvider) {
+            // ConfigurableParameters (continuous levers) are intentionally left out of
+            // this factory for now; they need a separate, carefully reviewed PR.
+            return new Dictionary<string, IConfigurableParameter>();
+        }
+
+        /// <summary>
+        /// Thin wrapper carrying the loaded bindings and HttpClient through
+        /// AbstractFactory's IServiceProvider parameter (the base ctor builds the
+        /// maps before the subclass body runs), without changing the base contract.
+        /// </summary>
+        private sealed class BindingsServiceProvider : IServiceProvider {
+            private readonly IServiceProvider _inner;
+
+            public BindingsServiceProvider(BindingsResult bindings, HttpClient httpClient, IServiceProvider inner) {
+                Bindings   = bindings;
+                HttpClient = httpClient;
+                _inner     = inner;
+            }
+
+            public BindingsResult Bindings   { get; }
+            public HttpClient     HttpClient { get; }
+
+            public object? GetService(Type serviceType) => _inner.GetService(serviceType);
+        }
+    }
+}

--- a/SmartNode/SmartNode/Program.cs
+++ b/SmartNode/SmartNode/Program.cs
@@ -82,6 +82,8 @@ namespace SmartNode
                     return new RoomM370Factory(serviceProvider);
                 } else if (coordinatorSettings.Environment.Equals("incubator")) {
                     return new IncubatorFactory(serviceProvider);
+                } else if (coordinatorSettings.Environment.Equals("homeassistant")) {
+                    return new HomeAssistantFactory(serviceProvider);
                 } else {
                     throw new Exception($"No factory found for environment {coordinatorSettings.Environment}.");
                 }

--- a/SmartNode/SmartNode/Properties/appsettings-ha.json
+++ b/SmartNode/SmartNode/Properties/appsettings-ha.json
@@ -1,0 +1,28 @@
+{
+  "FilepathArguments": {
+    "InferenceEngineFilepath": "models-and-rules/ruleless-digital-twins-inference-engine.jar",
+    "OntologyFilepath": "ontology/ruleless-digital-twins.ttl",
+    "InstanceModelFilepath": "models-and-rules/homeassistant-ha-instance.ttl",
+    "InferenceRulesFilepath": "models-and-rules/inference-rules.rules",
+    "InferredModelFilepath": "models-and-rules/homeassistant-ha-inferred.ttl",
+    "FmuDirectory": "SmartNode/Implementations/FMUs",
+    "DataDirectory": "state-data"
+  },
+  "CoordinatorSettings": {
+    "Environment": "homeassistant",
+    "SaveMapekCycleData": false,
+    "StartInReactiveMode": false,
+    "UseCaseBasedFunctionality": false,
+    "MaximumMapekRounds": 1,
+    "CycleDurationSeconds": 5,
+    "LookAheadMapekCycles": 1,
+    "PropertyValueFuzziness": 5,
+    "UseDecisionLagMitigation": false,
+    "UseRulelessMethod": true
+  },
+  "DatabaseSettings": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "CaseBase",
+    "CollectionName": "Cases"
+  }
+}

--- a/SmartNode/SmartNode/Services/Bindings/TtlBindingsLoader.cs
+++ b/SmartNode/SmartNode/Services/Bindings/TtlBindingsLoader.cs
@@ -1,0 +1,215 @@
+using VDS.RDF;
+using VDS.RDF.Parsing;
+
+namespace SmartNode.Services.Bindings {
+
+    public record SensorBinding(string Uri, string HaEntityId, string ObservesProperty, string ProcedureUri);
+
+    public record ActuatorBinding(string Uri, string HaEntityId, List<string> PossibleStates);
+
+    public record ConfigParamBinding(string Uri, string HaEntityId, string Field, List<string> PossibleValues);
+
+    public class BindingsResult {
+        public Dictionary<string, SensorBinding>       SensorMap      { get; } = new();
+        public Dictionary<string, ActuatorBinding>     ActuatorMap    { get; } = new();
+        public Dictionary<string, ConfigParamBinding>  ConfigParamMap { get; } = new();
+    }
+
+    public static class TtlBindingsLoader {
+
+        // Namespace constants — match what hacvt_rdt.py emits
+        private const string SosaNs = "http://www.w3.org/ns/sosa/";
+        private const string RdtNs  = "http://www.semanticweb.org/ivans/ontologies/2025/ruleless-digital-twins/";
+
+        private static readonly Uri SosaSensor   = new(SosaNs + "Sensor");
+        private static readonly Uri SosaActuator = new(SosaNs + "Actuator");
+        private static readonly Uri RdfType      = new("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+        private static readonly Uri RdfsSubClassOf = new("http://www.w3.org/2000/01/rdf-schema#subClassOf");
+
+        private const string SsnNs = "http://www.w3.org/ns/ssn/";
+
+        private static readonly Uri SosaObserves        = new(SosaNs + "observes");
+        private static readonly Uri SsnImplements       = new(SsnNs  + "implements");
+        private static readonly Uri RdtHasIdentifier        = new(RdtNs  + "hasIdentifier");
+        private static readonly Uri RdtHasActuatorState     = new(RdtNs  + "hasActuatorState");
+        private static readonly Uri RdtConfigurableParam    = new(RdtNs  + "ConfigurableParameter");
+        private static readonly Uri RdtHasActuatorName      = new(RdtNs  + "hasActuatorName");
+        private static readonly Uri RdtHasPossibleValue     = new(RdtNs  + "hasPossibleValue");
+
+        /// <summary>
+        /// Parses a Turtle file and returns sensor/actuator bindings derived from
+        /// sosa:Sensor / sosa:Actuator individuals.  Returns null if the file cannot
+        /// be read.
+        /// </summary>
+        public static BindingsResult? Load(string ttlPath) {
+            if (!File.Exists(ttlPath)) {
+                Console.WriteLine($"[TtlBindingsLoader] File not found: {ttlPath}");
+                return null;
+            }
+
+            var store = new TripleStore();
+            var parser = new TurtleParser();
+            IGraph g = new Graph();
+
+            try {
+                parser.Load(g, ttlPath);
+                store.Add(g);
+            } catch (Exception ex) {
+                Console.WriteLine($"[TtlBindingsLoader] Parse error in '{ttlPath}': {ex.Message}");
+                return null;
+            }
+
+            var result = new BindingsResult();
+
+            var typeNode           = g.CreateUriNode(RdfType);
+            var sensorType         = g.CreateUriNode(SosaSensor);
+            var actuatorType       = g.CreateUriNode(SosaActuator);
+            var configParamType    = g.CreateUriNode(RdtConfigurableParam);
+            var observesNode       = g.CreateUriNode(SosaObserves);
+            var implementsNode     = g.CreateUriNode(SsnImplements);
+            var identifierNode     = g.CreateUriNode(RdtHasIdentifier);
+            var stateNode          = g.CreateUriNode(RdtHasActuatorState);
+            var actuatorNameNode   = g.CreateUriNode(RdtHasActuatorName);
+            var possibleValueNode  = g.CreateUriNode(RdtHasPossibleValue);
+
+            // Resolve the set of types that count as Sensor / Actuator. Two TTL
+            // dialects exist in this project:
+            //   - upstream (incubator.ttl): individuals typed directly as
+            //     `a sosa:Sensor` / `a sosa:Actuator`.
+            //   - hacvt_rdt.py (HA export): individuals typed via a domain class
+            //     (e.g. `a hass:Fan`), where `hass:Fan rdfs:subClassOf sosa:Actuator`.
+            // Collect sosa:Sensor/Actuator plus every (transitive) subclass so
+            // both dialects resolve.
+            var sensorTypes   = CollectTypeAndSubclasses(g, sensorType);
+            var actuatorTypes = CollectTypeAndSubclasses(g, actuatorType);
+
+            int missingSensorId    = 0;
+            int missingActuatorId  = 0;
+            int statelessActuator  = 0;
+            int missingParamId     = 0;
+            int valuelessParam     = 0;
+
+            // ---- Sensors ----
+            foreach (var subject in InstancesOfTypes(g, typeNode, sensorTypes)) {
+                string uri          = subject.Uri.AbsoluteUri;
+                if (result.SensorMap.ContainsKey(uri)) continue;
+                string entityId     = GetLiteralObject(g, subject, identifierNode);
+                if (string.IsNullOrEmpty(entityId)) {
+                    Console.WriteLine($"[TtlBindingsLoader] WARNING: sensor '{uri}' has no rdt:hasIdentifier — it will not map to a runtime HA entity.");
+                    missingSensorId++;
+                }
+                string observes     = GetUriObject(g, subject, observesNode);
+                string procedureUri = GetUriObject(g, subject, implementsNode);
+                result.SensorMap[uri] = new SensorBinding(uri, entityId, observes, procedureUri);
+            }
+
+            // ---- Actuators ----
+            foreach (var subject in InstancesOfTypes(g, typeNode, actuatorTypes)) {
+                string uri      = subject.Uri.AbsoluteUri;
+                if (result.ActuatorMap.ContainsKey(uri)) continue;
+                string entityId = GetLiteralObject(g, subject, identifierNode);
+                if (string.IsNullOrEmpty(entityId)) {
+                    Console.WriteLine($"[TtlBindingsLoader] WARNING: actuator '{uri}' has no rdt:hasIdentifier — it will not map to a runtime HA entity.");
+                    missingActuatorId++;
+                }
+                var states      = g.GetTriplesWithSubjectPredicate(subject, stateNode)
+                                   .Select(st => st.Object is ILiteralNode ln ? ln.Value : "")
+                                   .Where(s => s != "")
+                                   .ToList();
+                if (states.Count == 0) {
+                    Console.WriteLine($"[TtlBindingsLoader] WARNING: actuator '{uri}' has no rdt:hasActuatorState — the planner cannot enumerate it.");
+                    statelessActuator++;
+                }
+                result.ActuatorMap[uri] = new ActuatorBinding(uri, entityId, states);
+            }
+
+            // ---- ConfigurableParameters ----
+            // Direct instances of rdt:ConfigurableParameter (not a subclass hierarchy needed here).
+            var configParamTypes = new HashSet<string> { RdtConfigurableParam.AbsoluteUri };
+            foreach (var subject in InstancesOfTypes(g, typeNode, configParamTypes)) {
+                string uri      = subject.Uri.AbsoluteUri;
+                if (result.ConfigParamMap.ContainsKey(uri)) continue;
+                string entityId = GetLiteralObject(g, subject, identifierNode);
+                if (string.IsNullOrEmpty(entityId)) {
+                    Console.WriteLine($"[TtlBindingsLoader] WARNING: configurable parameter '{uri}' has no rdt:hasIdentifier — it will not map to a runtime HA entity.");
+                    missingParamId++;
+                }
+                string field    = GetLiteralObject(g, subject, actuatorNameNode);
+                var values      = g.GetTriplesWithSubjectPredicate(subject, possibleValueNode)
+                                   .Select(st => st.Object is ILiteralNode ln ? ln.Value : "")
+                                   .Where(s => s != "")
+                                   .ToList();
+                if (values.Count == 0) {
+                    Console.WriteLine($"[TtlBindingsLoader] WARNING: configurable parameter '{uri}' has no rdt:hasPossibleValue — the planner cannot enumerate it.");
+                    valuelessParam++;
+                }
+                result.ConfigParamMap[uri] = new ConfigParamBinding(uri, entityId, field, values);
+            }
+
+            Console.WriteLine(
+                $"[TtlBindingsLoader] Loaded {result.SensorMap.Count} sensor(s), " +
+                $"{result.ActuatorMap.Count} actuator(s) and " +
+                $"{result.ConfigParamMap.Count} configurable parameter(s) from '{ttlPath}'.");
+            if (missingSensorId + missingActuatorId + statelessActuator + missingParamId + valuelessParam > 0) {
+                Console.WriteLine(
+                    $"[TtlBindingsLoader] WARNING summary: {missingSensorId} sensor(s) and " +
+                    $"{missingActuatorId} actuator(s) without an identifier, " +
+                    $"{statelessActuator} actuator(s) without states, " +
+                    $"{missingParamId} configurable parameter(s) without identifier, " +
+                    $"{valuelessParam} configurable parameter(s) without values.");
+            }
+
+            return result;
+        }
+
+        // -- Helpers --
+
+        /// <summary>
+        /// Returns the given base type plus every class that is, directly or
+        /// transitively, an rdfs:subClassOf of it. Lets the loader pick up
+        /// individuals typed via a domain subclass (e.g. hass:Fan) as well as
+        /// those typed directly as sosa:Sensor / sosa:Actuator.
+        /// </summary>
+        private static HashSet<string> CollectTypeAndSubclasses(IGraph g, IUriNode baseType) {
+            var result  = new HashSet<string> { baseType.Uri.AbsoluteUri };
+            var subClassOf = g.CreateUriNode(RdfsSubClassOf);
+            var frontier = new Queue<IUriNode>();
+            frontier.Enqueue(baseType);
+
+            while (frontier.Count > 0) {
+                var current = frontier.Dequeue();
+                // find ?sub rdfs:subClassOf current
+                foreach (Triple t in g.GetTriplesWithPredicateObject(subClassOf, current)) {
+                    if (t.Subject is IUriNode sub && result.Add(sub.Uri.AbsoluteUri)) {
+                        frontier.Enqueue(sub);
+                    }
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Yields the distinct IUriNode subjects whose rdf:type is in the given
+        /// type set.
+        /// </summary>
+        private static IEnumerable<IUriNode> InstancesOfTypes(IGraph g, IUriNode typeNode, HashSet<string> types) {
+            var seen = new HashSet<string>();
+            foreach (Triple t in g.GetTriplesWithPredicate(typeNode)) {
+                if (t.Object is not IUriNode objType) continue;
+                if (!types.Contains(objType.Uri.AbsoluteUri)) continue;
+                if (t.Subject is not IUriNode subject) continue;
+                if (seen.Add(subject.Uri.AbsoluteUri)) yield return subject;
+            }
+        }
+
+        private static string GetLiteralObject(IGraph g, IUriNode subject, IUriNode predicate) {
+            var triple = g.GetTriplesWithSubjectPredicate(subject, predicate).FirstOrDefault();
+            return triple?.Object is ILiteralNode ln ? ln.Value : string.Empty;
+        }
+
+        private static string GetUriObject(IGraph g, IUriNode subject, IUriNode predicate) {
+            var triple = g.GetTriplesWithSubjectPredicate(subject, predicate).FirstOrDefault();
+            return triple?.Object is IUriNode un ? un.Uri.AbsoluteUri : string.Empty;
+        }
+    }
+}

--- a/SmartNode/SmartNode/SmartNode.csproj
+++ b/SmartNode/SmartNode/SmartNode.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta7.25380.108" />
+    <PackageReference Include="dotNetRdf.Core" Version="3.3.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,6 +53,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
         <None Update="Properties\appsettings-incubator.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Properties\appsettings-ha.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/SmartNode/TestProject/HaActuatorTests.cs
+++ b/SmartNode/TestProject/HaActuatorTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using Implementations.Actuators.HomeAssistant;
+
+namespace TestProject;
+
+/// <summary>
+/// Offline tests for HaActuator: no live Home Assistant, no token. A recording
+/// HttpMessageHandler captures the outgoing request so we can assert the RDT
+/// state is translated to the correct HA service + payload, and that the actuator
+/// only records a new state once Home Assistant accepted the call.
+/// </summary>
+public class HaActuatorTests {
+
+    private sealed class RecordingHandler : HttpMessageHandler {
+        private readonly HttpStatusCode _status;
+        public string? RequestUri { get; private set; }
+        public string? RequestBody { get; private set; }
+
+        public RecordingHandler(HttpStatusCode status) => _status = status;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            RequestUri = request.RequestUri?.ToString();
+            RequestBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
+            return new HttpResponseMessage(_status);
+        }
+    }
+
+    private static (HaActuator actuator, RecordingHandler handler) Make(
+            string entityId, IReadOnlyList<string> states, HttpStatusCode status = HttpStatusCode.OK) {
+        var handler = new RecordingHandler(status);
+        var http = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:8123/") };
+        var actuator = new HaActuator(entityId, entityId, states, http);
+        return (actuator, handler);
+    }
+
+    [Fact]
+    public async Task On_maps_to_turn_on() {
+        var (actuator, handler) = Make("light.kitchen", new[] { "on", "off" });
+        await actuator.Actuate("on");
+        Assert.EndsWith("api/services/light/turn_on", handler.RequestUri);
+        Assert.Contains("light.kitchen", handler.RequestBody);
+    }
+
+    [Fact]
+    public async Task Off_maps_to_turn_off() {
+        var (actuator, handler) = Make("switch.lab", new[] { "on", "off" });
+        await actuator.Actuate("off");
+        Assert.EndsWith("api/services/switch/turn_off", handler.RequestUri);
+    }
+
+    [Fact]
+    public async Task Pct_maps_to_set_percentage_with_payload() {
+        var (actuator, handler) = Make("fan.bedroom", new[] { "pct:0", "pct:50" });
+        await actuator.Actuate("pct:50");
+        Assert.EndsWith("api/services/fan/set_percentage", handler.RequestUri);
+        Assert.Contains("\"percentage\":50", handler.RequestBody);
+    }
+
+    [Fact]
+    public async Task Preset_maps_to_set_preset_mode_with_payload() {
+        var (actuator, handler) = Make("climate.office", new[] { "preset:away", "preset:home" });
+        await actuator.Actuate("preset:away");
+        Assert.EndsWith("api/services/climate/set_preset_mode", handler.RequestUri);
+        Assert.Contains("\"preset_mode\":\"away\"", handler.RequestBody);
+    }
+
+    [Fact]
+    public async Task State_not_updated_when_http_call_fails() {
+        var (actuator, _) = Make("light.kitchen", new[] { "on", "off" }, HttpStatusCode.InternalServerError);
+        object before = actuator.ActuatorState; // initial = "on"
+        await Assert.ThrowsAsync<HttpRequestException>(() => actuator.Actuate("off"));
+        Assert.Equal(before, actuator.ActuatorState); // unchanged after failure
+    }
+}

--- a/SmartNode/TestProject/TtlBindingsLoaderTests.cs
+++ b/SmartNode/TestProject/TtlBindingsLoaderTests.cs
@@ -1,0 +1,90 @@
+using SmartNode.Services.Bindings;
+using Xunit;
+
+namespace TestProject
+{
+    /// <summary>
+    /// Bindings-layer verification for TtlBindingsLoader. Hermetic: writes small
+    /// in-memory TTL fixtures to a temp file and parses them — no FMU / Python /
+    /// Java and no external model files needed.
+    ///
+    /// Proves the loader resolves both TTL dialects used in this repo:
+    ///   - subclass typing:  :x a hass:Light, where hass:Light rdfs:subClassOf sosa:Actuator
+    ///   - direct typing:     :y a sosa:Actuator
+    /// </summary>
+    public class TtlBindingsLoaderTests
+    {
+        private const string Ttl = """
+            @prefix sosa: <http://www.w3.org/ns/sosa/> .
+            @prefix ssn:  <http://www.w3.org/ns/ssn/> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            @prefix rdt:  <http://www.semanticweb.org/ivans/ontologies/2025/ruleless-digital-twins/> .
+            @prefix ex:   <http://example.org/ha/> .
+            @prefix hass: <http://example.org/hass/> .
+
+            hass:Light rdfs:subClassOf sosa:Actuator .
+
+            ex:KitchenLight a hass:Light ;
+                rdt:hasIdentifier "light.kitchen" ;
+                rdt:hasActuatorState "on" ;
+                rdt:hasActuatorState "off" .
+
+            ex:LabFan a sosa:Actuator ;
+                rdt:hasIdentifier "fan.lab" ;
+                rdt:hasActuatorState "on" ;
+                rdt:hasActuatorState "off" .
+
+            ex:TempSensor a sosa:Sensor ;
+                rdt:hasIdentifier "sensor.temp" ;
+                sosa:observes ex:Temperature ;
+                ssn:implements ex:TempProcedure .
+            """;
+
+        private static BindingsResult LoadFixture()
+        {
+            string path = Path.Combine(Path.GetTempPath(), $"rdt-bindings-{Guid.NewGuid():N}.ttl");
+            File.WriteAllText(path, Ttl);
+            try
+            {
+                var result = TtlBindingsLoader.Load(path);
+                Assert.NotNull(result);
+                return result!;
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void Resolves_subclass_typed_actuator()
+        {
+            var result = LoadFixture();
+
+            // 2 actuators: KitchenLight (subclass of sosa:Actuator) + LabFan (direct).
+            // The subclass one is the regression target (was missed before the fix).
+            Assert.Equal(2, result.ActuatorMap.Count);
+            Assert.Contains(result.ActuatorMap.Values, a => a.HaEntityId == "light.kitchen");
+        }
+
+        [Fact]
+        public void Resolves_direct_typed_actuator_and_states()
+        {
+            var result = LoadFixture();
+
+            Assert.Contains(result.ActuatorMap.Values, a => a.HaEntityId == "fan.lab");
+            // Every actuator carries an entity id and at least one state.
+            Assert.All(result.ActuatorMap.Values, a => Assert.False(string.IsNullOrEmpty(a.HaEntityId)));
+            Assert.All(result.ActuatorMap.Values, a => Assert.NotEmpty(a.PossibleStates));
+        }
+
+        [Fact]
+        public void Resolves_sensor_with_identifier()
+        {
+            var result = LoadFixture();
+
+            Assert.Single(result.SensorMap);
+            Assert.Contains(result.SensorMap.Values, s => s.HaEntityId == "sensor.temp");
+        }
+    }
+}


### PR DESCRIPTION
## What

Runtime that drives a Home Assistant instance from the generated SOSA/RDT TTL:

- **`HomeAssistantFactory`** (selected by `Environment == "homeassistant"`)
  builds the sensor / actuator maps from the TTL via `TtlBindingsLoader`
  (handles both direct typing and subclass typing, e.g.
  `hass:Light rdfs:subClassOf sosa:Actuator`).
- **`HaActuator` + `HaActionTranslator`** map RDT states to real HA services
  (`on → turn_on`, `pct:50 → set_percentage`, `preset:X → set_preset_mode`, …);
  the state is recorded only after Home Assistant accepts the call.
- HA transport (HttpClient / bearer token) lives in `Implementations`
  (`HomeAssistantConnection`), so the generic core and `Program.cs` stay
  HA-agnostic — `Program.cs` only gains one generic `Environment` switch case.

## Notes

- `inference-rules.rules` is untouched.
- Tests: `HaActuatorTests` (offline, 5) + hermetic `TtlBindingsLoaderTests` (3).
- Adds `dotNetRdf.Core` to the SmartNode project.
- Verified end-to-end against a live HA instance: the factory loads the TTL and
  actuates a real light (`turn_on` / `turn_off`).

Depends on #78 (the exporter produces the TTL this runtime consumes).
Addresses #62
